### PR TITLE
Clean up mathjs dependency usage to fix scoping conflict with decimaljs

### DIFF
--- a/src/buffer/elastic-buffer.ts
+++ b/src/buffer/elastic-buffer.ts
@@ -1,4 +1,5 @@
 import { AsciiChars } from './ascii-chars'
+import { format } from 'mathjs'
 
 export class ElasticBuffer {
   private buffer: Buffer
@@ -110,9 +111,8 @@ export class ElasticBuffer {
       // integer
       return this.writeWholeNumber(v)
     } else {
-      const math = require('mathjs')
       // decimal with fraction turn to string
-      const s: string = math.format(v, { notation: 'fixed' })
+      const s: string = format(v, { notation: 'fixed' })
       return this.writeString(s)
     }
   }


### PR DESCRIPTION
Hi,

I'm currently using `jspurefix` for a FIX initiator implementation and created a `class FixAdapter extends AsciiSession` as shown in the [example project](https://github.com/TimelordUK/jspf-demo/). While using it I noticed a bug where the `Decimal` object used by `mathjs` (`jspurefix` dependency) seems to overwrite the `Decimal` object used by `decimaljs` (my project dependency). This came to light when another service was trying to deserialize this `Decimal` and threw the following error:

```
UnhandledPromiseRejectionWarning: Error: Error while trying to fetch. Original error message: [DecimalError] Invalid argument: [object Object]
```

where instead of a `"1"` it contained:

```
{
  "mathjs": "BigNumber",
  "value": "1"
}
```

It's a pretty niche case, but can be easily fixed by tweaking the `mathjs` import, as seen in the PR.