### PR TITLE
Fix initiator cleanup if the session is terminated unexpectedly

### DIFF
--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -137,7 +137,7 @@ export abstract class AsciiSession extends FixSession {
     this.send(MsgType.SequenceReset, resend)
   }
 
-  private onSessionMsg (msgType: string, view: MsgView): void {
+  protected onSessionMsg (msgType: string, view: MsgView): void {
 
     const factory = this.config.factory
     const logger = this.sessionLogger

--- a/src/transport/tcp/initiator.ts
+++ b/src/transport/tcp/initiator.ts
@@ -19,6 +19,7 @@ export function initiator (config: IJsFixConfig, sessionFactory: MakeFixSession,
         accept(true)
       } catch (e) {
         if (!reconnectTimeout) {
+          connecting = false
           reject(e)
         } else {
           logger.info(`waiting ${reconnectTimeout} to reconnect following error`)


### PR DESCRIPTION
Hi there,

A while ago I ran into a bug where the acceptor stopped sending heartbeats and my `jspurefix` initiator's Promise was rejected, triggering the shutdown of the service.

```typescript  
  try {
    await initiator(fixConfig, () => adapter);
  } catch (e: any) {
    logger.error(`Adapter failed with ${e.message}`);
  } finally {
    await shutdown();
  }
```

But then the transport kept running (the log is in newest-first order), which I'm guessing is not intended behaviour.
```
"2021-04-23T23:55:55.112Z [Acceptor-Name UAT client:FixSession] info: reset from previous transport.\n"
"2021-04-23T23:55:55.111Z [initiator] info: ... connected, run session\n"
"2021-04-23T23:55:55.109Z [Acceptor-Name UAT client:TcpInitiator] info: net.createConnection cb, resolving\n"
{
  "msg": "Shutting down...",
  "name": "@our-company/fix-adapter"
}
{
  "name": "@our-company/fix-adapter",
  "msg": "Adapter failed with Acceptor-Name UAT client: peer not responding"
}
```
[anonymised.log](https://github.com/TimelordUK/jspurefix/files/6377410/anonymised.log)

This PR should fix the issue :smiley: 