### PR TITLE
1.2.0 fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ to run the provided example tls trade capture a script such as script\getKey.ps1
   "Password": "pwd-tls-client",
   "EncryptMethod": 0,
   "ResetSeqNumFlag": true,
+  "LastSentSeqNum": 10,
+  "LastReceivedSeqNum": 11,
   "HeartBtInt": 30,
   "SenderCompId": "init-tls-comp",
   "TargetCompID": "accept-tls-comp",
@@ -194,6 +196,18 @@ i.e. include field BodyLengthChars which defaults to 7 characters if omitted.
 ```json
 {
   "BodsyLengthChars": 6
+}
+```
+
+## launching without resetting message sequences
+
+If the message sequences are persisted over multiple sessions and are not reset on logon (ie. `"ResetSeqNumFlag": false,`),
+then the previously used sequence numbers can be set as follows:
+```json
+{
+  "ResetSeqNumFlag": false,
+  "LastSentSeqNum": 10,
+  "LastReceivedSeqNum": 11
 }
 ```
 

--- a/src/test/session-state.test.ts
+++ b/src/test/session-state.test.ts
@@ -4,7 +4,7 @@ let state: FixSessionState
 let now: Date
 
 beforeEach(async () => {
-  state = new FixSessionState(30)
+  state = new FixSessionState({ heartBeat: 30 })
   state.state = SessionState.InitiationLogonResponse
   now = new Date(2018, 0, 1, 20, 0, 0, 0)
   state.LastSentAt = now

--- a/src/transport/fix-session-state.ts
+++ b/src/transport/fix-session-state.ts
@@ -36,6 +36,14 @@ export enum TickAction {
   Stop = 6
 }
 
+interface IFixSessionStateArgs {
+  heartBeat: number
+  state?: SessionState
+  waitLogoutConfirmSeconds?: number
+  stopSeconds?: number
+  lastPeerMsgSeqNum?: number
+}
+
 export class FixSessionState {
   public nextTickAction: TickAction = TickAction.Nothing
 
@@ -47,7 +55,11 @@ export class FixSessionState {
   public compId: string = ''
   public peerCompId: string = ''
   public peerHeartBeatSecs: number = 0
-  public lastPeerMsgSeqNum: number = 0
+  public lastPeerMsgSeqNum: number
+  public readonly heartBeat: number
+  public state: SessionState
+  public readonly waitLogoutConfirmSeconds: number
+  public readonly stopSeconds: number
 
   private secondsSinceLogoutSent: number = -1
   private secondsSinceSent: number = -1
@@ -67,11 +79,16 @@ export class FixSessionState {
     }
   }
 
-  public constructor (public readonly heartBeat: number,
-                      public state: SessionState = SessionState.Idle,
-                      public readonly waitLogoutConfirmSeconds: number = 5,
-                      public readonly stopSeconds: number = 2) {
-
+  public constructor ({ heartBeat,
+                        state = SessionState.Idle,
+                        waitLogoutConfirmSeconds = 5,
+                        stopSeconds = 2,
+                        lastPeerMsgSeqNum = 0 }: IFixSessionStateArgs) {
+    this.heartBeat = heartBeat
+    this.state = state
+    this.waitLogoutConfirmSeconds = waitLogoutConfirmSeconds
+    this.stopSeconds = stopSeconds
+    this.lastPeerMsgSeqNum = lastPeerMsgSeqNum
   }
 
   private static dateAsString (d: Date) {

--- a/src/transport/fix-session.ts
+++ b/src/transport/fix-session.ts
@@ -27,7 +27,9 @@ export abstract class FixSession extends events.EventEmitter {
     super()
     const description = config.description
     this.me = description.application.name
-    this.sessionState = new FixSessionState(description.HeartBtInt, config.description.LastReceivedSeqNum)
+    this.sessionState = new FixSessionState(
+      { heartBeat: config.description.HeartBtInt,
+        lastPeerMsgSeqNum: config.description.LastReceivedSeqNum})
     this.sessionLogger = config.logFactory.logger(`${this.me}:FixSession`)
     this.initiator = description.application.type === 'initiator'
     this.acceptor = !this.initiator


### PR DESCRIPTION
Hi there,

I was writing an acceptor with the library and noticed a few bugs to fix:

1. The session did not initialise with the input config's sequence numbers correctly (https://github.com/TimelordUK/jspurefix/commit/f911579fd7d546998c8d7ac419715ab156069324).
2. The `checkSeqNo()` method will trigger an endless resend loop if it notices a message gap on a `ResendRequest`. This is because it will then respond with a `ResendRequest` of its own, which can trigger another `ResendRequest` from the counterparty and so on. I have tweaked it to process `Logon` and `ResendRequest` before it sends its own `ResendRequest`. (https://github.com/TimelordUK/jspurefix/pull/20/commits/ed18daea7fcbcbdb09e06fdce35db8320a1f8eb5)

