### PR TITLE
1.2.0 fixup 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 script:
 - npm run tcp-tc
 - npm run http-oms
-- npm t src/test/ascii-encode.test.ts
+- npm t src/test/ascii-encoder.test.ts
 - npm t src/test/includes.test.ts
 - npm t src/test/fixml-mkt-data-settle-parse.test.ts
 - npm t src/test/repo-full-ascii-msg.test.ts

--- a/README.md
+++ b/README.md
@@ -211,6 +211,35 @@ then the previously used sequence numbers can be set as follows:
 }
 ```
 
+## resending messages
+
+By default, the library will not resend past messages as this requires persisting messages which depending on the volume, 
+may also require a database. If you want to support resending you must override `AsciiSession.onResendRequest()` with a resending logic.
+Additionally, make sure to include the original message sequence and the duplicate message flag in the FIX object:
+```typescript
+{
+  ...messageBodyData, 
+  StandardHeader: { PossDupFlag: true, MsgSeqNum: sequenceNumber},
+}
+
+```
+
+### Example
+```json
+{
+  "ClOrdID": "acceptor-order-id",
+  "HandlInst": "2",
+  "OrdType": "2",
+  "Side": "2",
+  "TransactTime": "2021-08-03T08:23:57.041Z",
+  "Symbol": "some ticker",
+  "StandardHeader": {
+    "PossDupFlag": true,
+    "MsgSeqNum": 2
+  }
+}
+```
+
 ## Unit Tests
 
 there is a comprehensive suite of tests which can be run

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ RUNS  src/test/session.test.ts
 PASS  src/test/encode-proxy.test.tsst.ts
 PASS  src/test/execution-report.test.ts
 PASS  src/test/view-decode.test.ts
-PASS  src/test/ascii-encode.test.ts
+PASS  src/test/ascii-encoder.test.ts
 PASS  src/test/ascii-parser.test.ts
 PASS  src/test/includes.test.ts
 PASS  src/test/fixml-alloc-parse.test.ts (9.433s)

--- a/src/buffer/ascii/ascii-encoder.ts
+++ b/src/buffer/ascii/ascii-encoder.ts
@@ -74,7 +74,8 @@ export class AsciiEncoder extends MsgEncoder {
     dispatchFields(fields, {
       simple: (sf: ContainedSimpleField) => {
         const val: any = objectToEncode[sf.name]
-        if (val != null) {
+        // Empty strings are omitted as they result in empty values for tags, which are considered malformed.
+        if (val != null && val !== '') {
           this.encodeSimple(objectToEncode, set, sf, val)
         }
       },

--- a/src/test/ascii-encoder.test.ts
+++ b/src/test/ascii-encoder.test.ts
@@ -111,14 +111,14 @@ test('encode string ClOrdID ', () => {
   expect(fix).toEqual('11=Order-a|')
 })
 
-test('encode empty string', () => {
+test('should not encode empty string', () => {
   const no: ILooseObject = {}
   no.ClOrdID = ''
   const fix: string = toFix(no)
-  expect(fix).toEqual('11=|')
+  expect(fix).toEqual('')
 })
 
-test('encode null string', () => {
+test('should not encode null string', () => {
   const no: ILooseObject = {}
   no.ClOrdID = null
   const fix: string = toFix(no)

--- a/src/transport/ascii/ascii-msg-transmitter.ts
+++ b/src/transport/ascii/ascii-msg-transmitter.ts
@@ -42,10 +42,13 @@ export class AsciiMsgTransmitter extends MsgTransmitter {
     const encoder: AsciiEncoder = this.encoder as AsciiEncoder
     const factory = this.config.factory
 
+    const { StandardHeader, ...bodyProps } = obj
+
     const headerProps: Partial<IStandardHeader> = {
-      ...(obj.StandardHeader?.PossDupFlag ? { PossDupFlag: obj.StandardHeader?.PossDupFlag } : {}),
-      ...(obj.StandardHeader?.MsgSeqNum ? { MsgSeqNum: obj.StandardHeader?.MsgSeqNum } : {})
+      ...(StandardHeader?.PossDupFlag ? { PossDupFlag: StandardHeader?.PossDupFlag } : {}),
+      ...(StandardHeader?.MsgSeqNum ? { MsgSeqNum: StandardHeader?.MsgSeqNum } : {})
     }
+
     const hdr: ILooseObject = factory.header(msgType, this.msgSeqNum,this.time || new Date(), headerProps)
 
     // Only increment sequence number if this is not a duplicate message.
@@ -60,7 +63,7 @@ export class AsciiMsgTransmitter extends MsgTransmitter {
       return
     }
     encoder.encode(hdr, this.header.name)
-    encoder.encode(obj, msgDef.name)
+    encoder.encode(bodyProps, msgDef.name)
     const lenPos = encoder.bodyLengthPos
     const bodyLength: number = Math.max(4, this.config.description.BodyLengthChars || 7)
     const len = buffer.getPos() - encoder.msgTypePos


### PR DESCRIPTION
Hi again,

This is the 2nd batch of fixes I wanted to write. They are as follows:

## Omit tags with empty string values https://github.com/TimelordUK/jspurefix/commit/752920fda2560316e90aaed3c2fda7572970608a

Effectively, this omits empty value tags like `57=|`. Here an example:
```
// Before
8=FIX4.2|9=0000085|35=A|49=init-comp|56=accept-comp|34=1|57=|52=20210803-07:16:14.167|98=0|108=30|141=Y|10=119|
// After
8=FIX4.2|9=0000081|35=A|49=init-comp|56=accept-comp|34=1|52=20210803-08:50:55.870|98=0|108=30|141=Y|10=206|
```
The reason for this is, that a counterparty is rejecting fields with empty values because it considers them malformed. This is in accordance with the standard: https://www.fixtrading.org/standards/tagvalue-online/.

## Duplicate header fields on resend https://github.com/TimelordUK/jspurefix/commit/fa39d3e9a05a1bf0520265c768bbfbf3560138c8

When resending an old FIX message some header fields (34 and 43) are duplicated. Example:
```
// Before
8=FIX4.2|9=0000160|35=D|49=init-comp|56=accept-comp|34=3|57=|43=Y|52=20210803-07:16:14.228|34=3|43=Y|11=initiator-order-id|21=2|55=dummy ticker|54=2|60=20210803-07:16:14.220|40=2|10=120|
// After
8=FIX4.2|9=0000146|35=D|49=init-comp|56=accept-comp|34=3|43=Y|52=20210803-08:50:55.933|11=initiator-order-id|21=2|55=dummy ticker|54=2|60=20210803-08:50:55.922|40=2|10=016|
```