### PR TITLE
#28 fix misplaced check of acceptor/initiator config files

### DIFF
--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -119,8 +119,8 @@ export abstract class SessionLauncher {
 
   private async setup () {
     this.sessionContainer.registerGlobal()
-    const server = this.initiatorConfig ? this.makeServer() : this.empty()
-    const client = this.acceptorConfig ? this.makeClient() : this.empty()
+    const server = this.acceptorConfig ? this.makeServer() : this.empty()
+    const client = this.initiatorConfig ? this.makeClient() : this.empty()
     this.logger.info('launching ....')
     return Promise.all([server, client])
   }


### PR DESCRIPTION
Closes #28 

- Swap check of acceptorConfig and initiatorConfig during setup

```typescript
private async setup () {
    this.sessionContainer.registerGlobal()
    const server = this.acceptorConfig ? this.makeServer() : this.empty()
    const client = this.initiatorConfig ? this.makeClient() : this.empty()
    this.logger.info('launching ....')
    return Promise.all([server, client])
}
```