### PR TITLE
Error handling improvements

### DIFF
--- a/src/transport/tcp/recovering-tcp-initiator.ts
+++ b/src/transport/tcp/recovering-tcp-initiator.ts
@@ -33,15 +33,11 @@ export class RecoveringTcpInitiator extends FixEntity {
     this.application = this.jsFixConfig.description.application
     this.logger = jsFixConfig.logFactory.logger(`${this.application.name}:RecoveringTcpInitiator`)
     if (!this.application) {
-      const e: Error = new Error(`no application in session description.`)
-      this.logger.error(e)
-      throw e
+      throw new Error(`no application in session description.`)
     }
     this.tcp = this.application.tcp
     if (!this.tcp) {
-      const e = new Error(`no tcp in session description need tcp { host: hostname, port: port }`)
-      this.logger.error(e)
-      throw e
+      throw new Error(`no tcp in session description need tcp { host: hostname, port: port }`)
     }
     this.createSession(jsFixConfig)
   }
@@ -82,7 +78,7 @@ export class RecoveringTcpInitiator extends FixEntity {
       }
     }).catch(e => {
       this.logger.info(`transport id ${(transport.id)} failed - session state ${session.getState()}`)
-      this.logger.error(e.message)
+      this.logger.warning(e.message)
       this.recover()
     })
     this.logger.info(`running session with transport ${transport.id} state = ${session.getState()}`)

--- a/src/transport/tcp/tcp-initiator-connector.ts
+++ b/src/transport/tcp/tcp-initiator-connector.ts
@@ -56,15 +56,10 @@ export class TcpInitiatorConnector extends FixEntity {
     const logger = this.config.logFactory.logger('initiator')
     const initiator: FixInitiator = this.config.sessionContainer.resolve<FixInitiator>(TcpInitiator)
     logger.info('connecting ...')
-    try {
-      const initiatorTransport: MsgTransport = await initiator.connect(22)
-      logger.info('... connected, run session')
-      await initiatorSession.run(initiatorTransport)
-      logger.info('ends')
-      return true
-    } catch (e) {
-      logger.error(e)
-      throw e
-    }
+    const initiatorTransport: MsgTransport = await initiator.connect(22)
+    logger.info('... connected, run session')
+    await initiatorSession.run(initiatorTransport)
+    logger.info('ends')
+    return true
   }
 }


### PR DESCRIPTION
1. I believe that only errors that are unhandled should be written to the **logger.error** and it is up to the developer who uses the library to handle them or not. Otherwise, we end up logging errors multiple times.  For instance, we have our developers notified if there was an unhandled error in the code.  In case when it is logged into error inside the library we can't distinguish if it is handled error or not.

2. I've changed the code where we are rejecting a promise if a timeout happens while connecting. Now we save the error and throw it instead of just a new error. Use case: we want to understand what was the error by analyzing the original socket error code, so we can understand that it was socket error and react in code accordingly if we want to retry or not.