### PR TITLE
Pass config options and logger factory via session launcher

### DIFF
--- a/src/runtime/session-container.ts
+++ b/src/runtime/session-container.ts
@@ -1,6 +1,6 @@
 import { container, DependencyContainer } from 'tsyringe'
 import { DefinitionFactory } from '../util'
-import { IJsFixConfig, JsFixWinstonLogFactory, WinstonLogger } from '../config'
+import { IJsFixConfig, JsFixLoggerFactory, JsFixWinstonLogFactory, WinstonLogger } from '../config'
 import { DITokens } from './di-tokens'
 import { RuntimeFactory } from './make-config'
 
@@ -24,9 +24,16 @@ export class SessionContainer {
     container.reset()
   }
 
-  public registerGlobal (level: string = 'info'): void {
+  public registerGlobal (loggerFactory: JsFixLoggerFactory): void;
+  public registerGlobal (level?: string): void;
+  public registerGlobal (levelOrLoggerFactory: string | JsFixLoggerFactory = 'info'): void {
     container.registerInstance(DefinitionFactory, new DefinitionFactory())
-    const lf = new JsFixWinstonLogFactory(WinstonLogger.consoleOptions(level))
+    let lf: JsFixLoggerFactory;
+    if (typeof levelOrLoggerFactory === 'string') {
+      lf = new JsFixWinstonLogFactory(WinstonLogger.consoleOptions(levelOrLoggerFactory))
+    } else {
+      lf = levelOrLoggerFactory;
+    }
     container.registerInstance(DITokens.JsFixLoggerFactory, lf)
     container.register<RuntimeFactory>(RuntimeFactory, {
       useClass: RuntimeFactory

--- a/src/runtime/session-container.ts
+++ b/src/runtime/session-container.ts
@@ -24,8 +24,8 @@ export class SessionContainer {
     container.reset()
   }
 
-  public registerGlobal (loggerFactory: JsFixLoggerFactory): void;
-  public registerGlobal (level?: string): void;
+  public registerGlobal (loggerFactory?: JsFixLoggerFactory): void;
+  public registerGlobal (level: string): void;
   public registerGlobal (levelOrLoggerFactory: string | JsFixLoggerFactory = 'info'): void {
     container.registerInstance(DefinitionFactory, new DefinitionFactory())
     let lf: JsFixLoggerFactory;


### PR DESCRIPTION
While integrating jspurefix in an app, I realized there is no way to pass a custom logger. Also, there is no way to pass session options without storing them in a file.

This PR addresses both issues. It keeps the existing functionality intact, so it does not break backwards compatibility.

There is a slight change in the public API: The type of `SessionLauncher.initiatorconfig` and `SessionLauncher.acceptorConfig` is now `ISessionDescription`. Before, it was `string`.

Please let me know what you think. I am happy to improve on this PR, if required.