### PR TITLE
Enable supplying node native TLS options

### DIFF
--- a/src/transport/tcp/tls-options-factory.ts
+++ b/src/transport/tcp/tls-options-factory.ts
@@ -31,6 +31,12 @@ export class TlsOptionsFactory {
         tlsOptions.ca = tls.ca.map(i => TlsOptionsFactory.read(i))
       }
     }
+    if (tls.nodeTlsServerOptions) {
+      tlsOptions = {
+        ...tlsOptions,
+        ...tls.nodeTlsServerOptions,
+      }
+    }
     return tlsOptions
   }
 
@@ -54,6 +60,12 @@ export class TlsOptionsFactory {
       }
       if (tcp.tls.sessionTimeout) {
         connectionOptions.sessionTimeout = tcp.tls.sessionTimeout
+      }
+    }
+    if (tls.nodeTlsConnectionOptions) {
+      connectionOptions = {
+        ...connectionOptions,
+        ...tls.nodeTlsConnectionOptions,
       }
     }
     return connectionOptions

--- a/src/transport/tcp/tls-options-factory.ts
+++ b/src/transport/tcp/tls-options-factory.ts
@@ -30,11 +30,12 @@ export class TlsOptionsFactory {
       if (tls.ca && tls.ca.length > 0) {
         tlsOptions.ca = tls.ca.map(i => TlsOptionsFactory.read(i))
       }
-    }
-    if (tls.nodeTlsServerOptions) {
-      tlsOptions = {
-        ...tlsOptions,
-        ...tls.nodeTlsServerOptions,
+
+      if (tls.nodeTlsServerOptions) {
+        tlsOptions = {
+          ...tlsOptions,
+          ...tls.nodeTlsServerOptions,
+        }
       }
     }
     return tlsOptions
@@ -61,11 +62,11 @@ export class TlsOptionsFactory {
       if (tcp.tls.sessionTimeout) {
         connectionOptions.sessionTimeout = tcp.tls.sessionTimeout
       }
-    }
-    if (tls.nodeTlsConnectionOptions) {
-      connectionOptions = {
-        ...connectionOptions,
-        ...tls.nodeTlsConnectionOptions,
+      if (tls.nodeTlsConnectionOptions) {
+        connectionOptions = {
+          ...connectionOptions,
+          ...tls.nodeTlsConnectionOptions,
+        }
       }
     }
     return connectionOptions

--- a/src/transport/tcp/tls-options.ts
+++ b/src/transport/tcp/tls-options.ts
@@ -1,3 +1,5 @@
+import { ConnectionOptions, TlsOptions } from "tls"
+
 export interface ITlsOptions {
   readonly key: string,
   readonly cert: string,
@@ -6,5 +8,7 @@ export interface ITlsOptions {
   readonly sessionTimeout?: number,
   readonly enableTrace?: boolean,
   readonly requestCert?: boolean,
-  readonly rejectUnauthorized?: boolean
+  readonly rejectUnauthorized?: boolean,
+  readonly nodeTlsConnectionOptions?: ConnectionOptions,
+  readonly nodeTlsServerOptions?: TlsOptions
 }

--- a/src/transport/tcp/tls-options.ts
+++ b/src/transport/tcp/tls-options.ts
@@ -1,8 +1,8 @@
 import { ConnectionOptions, TlsOptions } from "tls"
 
 export interface ITlsOptions {
-  readonly key: string,
-  readonly cert: string,
+  readonly key?: string,
+  readonly cert?: string,
   readonly ca?: string[],
   readonly timeout?: number,
   readonly sessionTimeout?: number,


### PR DESCRIPTION
While using the library, I noticed it is impossible to pass native Node.JS TLS options to the underlying TLS implementation. I added these as additional options to the existing `ITlsOptions` interface, so everything is backwards-compatible. This still keeps the same functionality for the existing properties, but allows the user to overwrite any option using the newly added properties.