### PR TITLE
Gap fill with wrong seq num & not inflating correctly if end seq is 0

### DIFF
--- a/src/test/ascii/ascii-store-replay.test.ts
+++ b/src/test/ascii/ascii-store-replay.test.ts
@@ -120,7 +120,8 @@ function checkSeqReset (rec: IFixMsgStoreRecord, from: number, to: number): void
   const reset: ISequenceReset = rec.obj as ISequenceReset
   expect(rec.msgType).toEqual(MsgType.SequenceReset)
   expect(rec.obj).toBeTruthy()
-  expect(rec.seqNum).toEqual(to)
+  expect(rec.seqNum).toEqual(from)
+  expect(reset.NewSeqNo).toEqual(to)
   expect(reset.GapFillFlag).toBeTruthy()
   expect(reset.StandardHeader.MsgType).toEqual(MsgType.SequenceReset)
   expect(reset.StandardHeader.PossDupFlag).toBeTruthy()

--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -160,7 +160,11 @@ export abstract class AsciiSession extends FixSession {
   protected onResendRequest (view: MsgView): void {
     // if no records are in store then send a gap fill for entire sequence
     this.setState(SessionState.HandleResendRequest)
-    const [beginSeqNo, endSeqNo] = view.getTypedTags([MsgTag.BeginSeqNo, MsgTag.EndSeqNo])
+    const [beginSeqNo, requestedEndSeqNo] = view.getTypedTags([MsgTag.BeginSeqNo, MsgTag.EndSeqNo])
+    const endSeqNo = requestedEndSeqNo === 0
+      ? this.sessionState.lastSentSeqNum()
+      : requestedEndSeqNo
+
     this.sessionLogger.info(`onResendRequest getResendRequest beginSeqNo = ${beginSeqNo}, endSeqNo = ${endSeqNo}`)
     this.resender.getResendRequest(beginSeqNo as number, endSeqNo as number).then((records: IFixMsgStoreRecord[]) => {
       const validRecords = records.filter(rec => rec.obj !== null)


### PR DESCRIPTION
Found three minor issues.

One in `sequenceResetGap`, where the gap fill seq num was set with `newSeq` (should be `startGap`, because the seq num represents the start of the gap).

Another issue is when the `endSeqNo` is `0`. The existing code doesn't handle this scenario, and no gap fills are created. In this case, when the end seq no is 0, we should consider it as the latest seq num sent to the other peer (that's why I get it from `this.sessionState.lastSentSeqNum()`, but let me know if this inaccurate).

And the last issue is when we resend messages with zero messages retrieved from the store. In a situation where the only message sent to the other peer is `login` (seq num=1), for example, the store will be empty. But still, we have to generate a gap fill from `1` to `1` to respond to the `ResendRequest` message. The current code doesn't return anything (empty array of messages to be sent to peer).