### PR TITLE
feat: add ResendGapFillOnly safety mode (PR 5B)

### DIFF
--- a/BACKPORT_PLAN.md
+++ b/BACKPORT_PLAN.md
@@ -215,11 +215,9 @@ Storm protection was largely wired during PR 3C/3D. Remaining gaps completed:
 
 | File | Action |
 |------|--------|
-| `src/config/js-fix-config.ts` | Add optional `resendGapFillOnly?: boolean` |
-| `src/store/fix-msg-ascii-store-resend.ts` | Early return path when enabled — always GapFill instead of replaying |
-| New: `src/test/store/resend-gap-fill-only.test.ts` | ~3 tests |
+### Status: **DONE**
 
-Can be done at **any time** — independent of all other PRs.
+Added `resendGapFillOnly` option to `StoreConfig`. When enabled, `FixMsgAsciiStoreResend` always returns a single GapFill instead of replaying stored messages — prevents accidental duplicate order execution for client/initiator sessions. 5 tests added.
 
 ---
 
@@ -250,7 +248,7 @@ PR 5B (ResendGapFillOnly) ──── independent, can be done anytime
 | 4C | Low | New file, tested with mocks — **DONE** (PR #120) |
 | 4D | Medium | Changes send path, store errors must not block sends — **DONE** |
 | 5A | Low | Wiring only, coordinator makes decisions — **DONE** |
-| 5B | None | Additive config option |
+| 5B | None | Additive config option — **DONE** |
 
 ---
 

--- a/src/store/fix-msg-ascii-store-resend.ts
+++ b/src/store/fix-msg-ascii-store-resend.ts
@@ -13,6 +13,14 @@ export class FixMsgAsciiStoreResend {
   }
 
   public async getResendRequest (startSeq: number, endSeq: number): Promise<IFixMsgStoreRecord[]> {
+    // Safety feature: If ResendGapFillOnly is enabled, ALWAYS send GapFill instead of
+    // replaying stored messages. This prevents accidental duplicate order execution.
+    if (this.config.description.store?.resendGapFillOnly === true) {
+      const gapFillOnly: IFixMsgStoreRecord[] = []
+      this.gap(startSeq, endSeq + 1, gapFillOnly)
+      return gapFillOnly
+    }
+
     // need to cover request from start to end where any missing numbers are
     // included as gaps to allow vector of messages to be sent by the session
     // on a request

--- a/src/store/store-config.ts
+++ b/src/store/store-config.ts
@@ -12,4 +12,5 @@
 export interface StoreConfig {
   readonly type: 'memory' | 'file'
   readonly directory?: string
+  readonly resendGapFillOnly?: boolean
 }

--- a/src/test/store/resend-gap-fill-only.test.ts
+++ b/src/test/store/resend-gap-fill-only.test.ts
@@ -1,0 +1,92 @@
+import 'reflect-metadata'
+
+import * as path from 'path'
+
+import { IFixMsgStoreRecord } from '../../store'
+import { MsgType } from '../../types'
+import { ISequenceReset } from '../../types/FIX4.4/repo'
+
+import { Setup } from '../env/setup'
+import { TestRecovery } from '../env/test-recovery'
+
+const root: string = path.join(__dirname, '../../../data')
+
+let server: TestRecovery
+let serverGapFillOnly: TestRecovery
+let setup: Setup
+
+beforeAll(async () => {
+  setup = new Setup(
+    'session/test-initiator.json',
+    'session/test-acceptor.json')
+  await setup.init()
+  const serverConfig = setup.serverConfig
+  const views = await setup.server.replayer.replayFixFile(path.join(root, 'examples/FIX.4.4/jsfix.test_client.txt'))
+
+  // Normal resend (replays stored messages)
+  server = new TestRecovery(views, serverConfig)
+  await server.populate()
+
+  // GapFillOnly resend (always gap-fills, never replays)
+  const gapFillConfig = {
+    ...serverConfig,
+    description: {
+      ...serverConfig.description,
+      store: { type: 'memory' as const, resendGapFillOnly: true }
+    }
+  }
+  serverGapFillOnly = new TestRecovery(views, gapFillConfig)
+  await serverGapFillOnly.populate()
+}, 45000)
+
+function checkSeqReset (rec: IFixMsgStoreRecord, from: number, to: number): void {
+  const reset: ISequenceReset = rec.obj as ISequenceReset
+  expect(rec.msgType).toEqual(MsgType.SequenceReset)
+  expect(rec.obj).toBeTruthy()
+  expect(rec.seqNum).toEqual(from)
+  expect(reset.NewSeqNo).toEqual(to)
+  expect(reset.GapFillFlag).toBeTruthy()
+  expect(reset.StandardHeader.PossDupFlag).toBeTruthy()
+}
+
+test('normal mode replays stored messages', async () => {
+  const vec = await server.recovery.getResendRequest(1, 10)
+  expect(vec.length).toEqual(10)
+  // Should contain actual messages, not just gap fills
+  const nonGapFills = vec.filter(r => r.msgType !== MsgType.SequenceReset)
+  expect(nonGapFills.length).toBeGreaterThan(0)
+})
+
+test('gap-fill-only mode returns single gap fill for full range', async () => {
+  const vec = await serverGapFillOnly.recovery.getResendRequest(1, 10)
+  expect(vec.length).toEqual(1)
+  checkSeqReset(vec[0], 1, 11)
+})
+
+test('gap-fill-only mode with empty store returns gap fill', async () => {
+  // Create a recovery with an empty store but gapFillOnly enabled
+  const emptyConfig = {
+    ...setup.serverConfig,
+    description: {
+      ...setup.serverConfig.description,
+      store: { type: 'memory' as const, resendGapFillOnly: true }
+    }
+  }
+  const emptyRecovery = new TestRecovery([], emptyConfig)
+  // Don't populate — store is empty
+  const vec = await emptyRecovery.recovery.getResendRequest(1, 10)
+  expect(vec.length).toEqual(1)
+  checkSeqReset(vec[0], 1, 11)
+})
+
+test('gap-fill-only mode with partial range', async () => {
+  const vec = await serverGapFillOnly.recovery.getResendRequest(5, 8)
+  expect(vec.length).toEqual(1)
+  checkSeqReset(vec[0], 5, 9)
+})
+
+test('gap-fill-only mode with single sequence', async () => {
+  const vec = await serverGapFillOnly.recovery.getResendRequest(3, 3)
+  expect(vec.length).toEqual(1)
+  checkSeqReset(vec[0], 3, 4)
+})


### PR DESCRIPTION
## Summary
- Add `resendGapFillOnly` option to `StoreConfig` — when enabled, `FixMsgAsciiStoreResend` always returns a single GapFill instead of replaying stored messages
- Prevents accidental duplicate order execution for client/initiator sessions
- Configured via session JSON: `"store": { "type": "file", "resendGapFillOnly": true }`
- Update BACKPORT_PLAN.md to mark Phase 5B as done

## Test plan
- [x] 5 new tests covering: normal replay, gap-fill-only full range, empty store, partial range, single sequence
- [x] All 392 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)