### PR TITLE
feat: add XElement tree builder — SAX wrapper for DOM-like XML access (PR 6A)

### DIFF
--- a/src/dictionary/parser/quickfix/index.ts
+++ b/src/dictionary/parser/quickfix/index.ts
@@ -1,1 +1,3 @@
 export * from './quick-fix-xml-file-parser'
+export * from './x-element'
+export * from './sax-tree-builder'

--- a/src/dictionary/parser/quickfix/sax-tree-builder.ts
+++ b/src/dictionary/parser/quickfix/sax-tree-builder.ts
@@ -1,0 +1,112 @@
+import { XDocument, XElement } from './x-element'
+
+/**
+ * Builds an in-memory XElement tree from XML using a single SAX pass.
+ * After construction, the tree provides DOM-like random access for
+ * graph-based parsing and validation.
+ */
+export class SaxTreeBuilder {
+  /**
+   * Parse XML text into an XDocument.
+   */
+  static parse (xml: string): XDocument {
+    const sax = require('sax')
+    const parser = sax.parser(true, {})
+    const stack: XElement[] = []
+    let root: XElement | null = null
+    let lastWasSelfClosing = false
+
+    parser.onopentag = (node: { name: string, attributes: Record<string, string>, isSelfClosing: boolean }) => {
+      const element: XElement = {
+        name: node.name,
+        attributes: { ...node.attributes },
+        children: [],
+        line: parser.line + 1
+      }
+
+      if (stack.length > 0) {
+        stack[stack.length - 1].children.push(element)
+      }
+
+      lastWasSelfClosing = node.isSelfClosing
+      if (!node.isSelfClosing) {
+        stack.push(element)
+      }
+      if (!root) root = element
+    }
+
+    parser.onclosetag = () => {
+      if (lastWasSelfClosing) {
+        lastWasSelfClosing = false
+        return
+      }
+      stack.pop()
+    }
+
+    parser.onerror = (err: Error) => {
+      throw new Error(`XML parse error at line ${parser.line + 1}: ${err.message}`)
+    }
+
+    parser.write(xml).close()
+
+    if (!root) {
+      throw new Error('empty XML document')
+    }
+
+    return new XDocument(root)
+  }
+
+  /**
+   * Parse XML from a readable stream into an XDocument.
+   */
+  static async parseStream (readable: NodeJS.ReadableStream): Promise<XDocument> {
+    return await new Promise<XDocument>((resolve, reject) => {
+      const sax = require('sax')
+      const saxStream = sax.createStream(true, {})
+      const stack: XElement[] = []
+      let root: XElement | null = null
+      let lastWasSelfClosing = false
+
+      saxStream.on('opentag', (node: { name: string, attributes: Record<string, string>, isSelfClosing: boolean }) => {
+        const element: XElement = {
+          name: node.name,
+          attributes: { ...node.attributes },
+          children: [],
+          line: saxStream._parser.line + 1
+        }
+
+        if (stack.length > 0) {
+          stack[stack.length - 1].children.push(element)
+        }
+
+        lastWasSelfClosing = node.isSelfClosing
+        if (!node.isSelfClosing) {
+          stack.push(element)
+        }
+        if (!root) root = element
+      })
+
+      saxStream.on('closetag', () => {
+        if (lastWasSelfClosing) {
+          lastWasSelfClosing = false
+          return
+        }
+        stack.pop()
+      })
+
+      saxStream.on('error', (err: Error) => {
+        reject(new Error(`XML parse error: ${err.message}`))
+      })
+
+      saxStream.on('end', () => {
+        if (!root) {
+          reject(new Error('empty XML document'))
+        } else {
+          resolve(new XDocument(root))
+        }
+      })
+
+      readable.pipe(saxStream)
+    })
+  }
+}

--- a/src/dictionary/parser/quickfix/x-element.ts
+++ b/src/dictionary/parser/quickfix/x-element.ts
@@ -1,0 +1,111 @@
+/**
+ * Lightweight in-memory XML element tree — provides DOM-like random access
+ * over XML parsed by SAX. Mirrors the C# XDocument/XElement API surface
+ * used by QuickFixXmlFileParser and DictionaryValidator.
+ */
+export interface XElement {
+  readonly name: string
+  readonly attributes: Record<string, string>
+  readonly children: XElement[]
+  readonly line?: number
+}
+
+/**
+ * Query helper wrapping an XElement tree with C#-style traversal methods.
+ * Mirrors XDocument/XElement LINQ-to-XML API used in cspurefix.
+ */
+export class XNode {
+  constructor (public readonly element: XElement) {}
+
+  /** Attribute value by name, or undefined if not present. */
+  attribute (name: string): string | undefined {
+    return this.element.attributes[name]
+  }
+
+  /** Direct children with the given tag name. */
+  elements (name?: string): XNode[] {
+    const children = name
+      ? this.element.children.filter(c => c.name === name)
+      : this.element.children
+    return children.map(c => new XNode(c))
+  }
+
+  /** First direct child with the given tag name, or undefined. */
+  firstElement (name: string): XNode | undefined {
+    const child = this.element.children.find(c => c.name === name)
+    return child ? new XNode(child) : undefined
+  }
+
+  /** All descendants (recursive) with the given tag name. */
+  descendants (name: string): XNode[] {
+    const result: XNode[] = []
+    this.collectDescendants(this.element, name, result)
+    return result
+  }
+
+  /** First descendant with the given tag name, or undefined. */
+  firstDescendant (name: string): XNode | undefined {
+    return this.findDescendant(this.element, name)
+  }
+
+  /** Shorthand: attribute value, throwing if missing. */
+  requiredAttribute (name: string): string {
+    const val = this.element.attributes[name]
+    if (val === undefined) {
+      throw new Error(`missing required attribute '${name}' on <${this.element.name}> at line ${this.element.line ?? '?'}`)
+    }
+    return val
+  }
+
+  /** The element's tag name. */
+  get name (): string {
+    return this.element.name
+  }
+
+  /** The element's source line number, if available. */
+  get line (): number | undefined {
+    return this.element.line
+  }
+
+  private collectDescendants (el: XElement, name: string, result: XNode[]): void {
+    for (const child of el.children) {
+      if (child.name === name) {
+        result.push(new XNode(child))
+      }
+      this.collectDescendants(child, name, result)
+    }
+  }
+
+  private findDescendant (el: XElement, name: string): XNode | undefined {
+    for (const child of el.children) {
+      if (child.name === name) {
+        return new XNode(child)
+      }
+      const found = this.findDescendant(child, name)
+      if (found) return found
+    }
+    return undefined
+  }
+}
+
+/**
+ * Parsed XML document — wraps the root element with query methods.
+ * Equivalent to C# XDocument.
+ */
+export class XDocument {
+  public readonly root: XNode
+
+  constructor (rootElement: XElement) {
+    this.root = new XNode(rootElement)
+  }
+
+  /** All descendants of the root with the given tag name. */
+  descendants (name: string): XNode[] {
+    return this.root.descendants(name)
+  }
+
+  /** First descendant of the root with the given tag name. */
+  firstDescendant (name: string): XNode | undefined {
+    return this.root.firstDescendant(name)
+  }
+}

--- a/src/test/dictionary/sax-tree-builder.test.ts
+++ b/src/test/dictionary/sax-tree-builder.test.ts
@@ -1,0 +1,221 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { SaxTreeBuilder } from '../../dictionary/parser/quickfix/sax-tree-builder'
+import { XDocument } from '../../dictionary/parser/quickfix/x-element'
+
+const dataRoot = path.join(__dirname, '../../../data')
+
+describe('SaxTreeBuilder.parse', () => {
+  test('parse minimal XML', () => {
+    const doc = SaxTreeBuilder.parse('<fix major="4" minor="4"><fields></fields></fix>')
+    expect(doc.root.name).toBe('fix')
+    expect(doc.root.attribute('major')).toBe('4')
+    expect(doc.root.attribute('minor')).toBe('4')
+    expect(doc.root.elements('fields').length).toBe(1)
+  })
+
+  test('parse self-closing elements', () => {
+    const xml = '<fix><fields><field name="Account" number="1" type="STRING" /></fields></fix>'
+    const doc = SaxTreeBuilder.parse(xml)
+    const fields = doc.firstDescendant('fields')
+    expect(fields).toBeDefined()
+    const fieldNodes = fields!.elements('field')
+    expect(fieldNodes.length).toBe(1)
+    expect(fieldNodes[0].attribute('name')).toBe('Account')
+    expect(fieldNodes[0].attribute('number')).toBe('1')
+    expect(fieldNodes[0].attribute('type')).toBe('STRING')
+  })
+
+  test('parse nested structure', () => {
+    const xml = `
+      <fix major="4" minor="4">
+        <components>
+          <component name="Instrument">
+            <field name="Symbol" required="Y" />
+            <field name="SecurityID" required="N" />
+            <component name="InstrumentExtension" required="N" />
+          </component>
+        </components>
+      </fix>`
+    const doc = SaxTreeBuilder.parse(xml)
+    const component = doc.firstDescendant('component')
+    expect(component).toBeDefined()
+    expect(component!.attribute('name')).toBe('Instrument')
+    expect(component!.elements('field').length).toBe(2)
+    expect(component!.elements('component').length).toBe(1)
+  })
+
+  test('descendants finds at all depths', () => {
+    const xml = `
+      <fix>
+        <messages>
+          <message name="Heartbeat" msgtype="0">
+            <field name="TestReqID" required="N" />
+          </message>
+          <message name="Logon" msgtype="A">
+            <field name="EncryptMethod" required="Y" />
+            <group name="NoMsgTypes" required="N">
+              <field name="RefMsgType" required="N" />
+            </group>
+          </message>
+        </messages>
+      </fix>`
+    const doc = SaxTreeBuilder.parse(xml)
+    const allFields = doc.descendants('field')
+    expect(allFields.length).toBe(3)
+    const messages = doc.descendants('message')
+    expect(messages.length).toBe(2)
+  })
+
+  test('firstDescendant returns first match', () => {
+    const xml = '<fix><fields><field name="A" /><field name="B" /></fields></fix>'
+    const doc = SaxTreeBuilder.parse(xml)
+    const first = doc.firstDescendant('field')
+    expect(first).toBeDefined()
+    expect(first!.attribute('name')).toBe('A')
+  })
+
+  test('firstDescendant returns undefined for no match', () => {
+    const doc = SaxTreeBuilder.parse('<fix></fix>')
+    expect(doc.firstDescendant('nonexistent')).toBeUndefined()
+  })
+
+  test('requiredAttribute throws on missing', () => {
+    const doc = SaxTreeBuilder.parse('<fix></fix>')
+    expect(() => doc.root.requiredAttribute('major')).toThrow('missing required attribute')
+  })
+
+  test('elements without name returns all children', () => {
+    const xml = '<fix><header /><trailer /><fields /></fix>'
+    const doc = SaxTreeBuilder.parse(xml)
+    expect(doc.root.elements().length).toBe(3)
+  })
+
+  test('line numbers are tracked', () => {
+    const xml = '<fix>\n<fields>\n<field name="A" />\n</fields>\n</fix>'
+    const doc = SaxTreeBuilder.parse(xml)
+    expect(doc.root.line).toBe(1)
+    const field = doc.firstDescendant('field')
+    expect(field).toBeDefined()
+    expect(field!.line).toBe(3)
+  })
+
+  test('empty XML throws', () => {
+    expect(() => SaxTreeBuilder.parse('')).toThrow()
+  })
+})
+
+describe('SaxTreeBuilder with real FIX dictionaries', () => {
+  const fixFiles = ['FIX42.xml', 'FIX43.xml', 'FIX44.xml', 'FIX50SP2.xml']
+
+  fixFiles.forEach(file => {
+    const filePath = path.join(dataRoot, file)
+    if (!fs.existsSync(filePath)) return
+
+    describe(file, () => {
+      let doc: XDocument
+
+      beforeAll(() => {
+        const xml = fs.readFileSync(filePath, 'utf-8')
+        doc = SaxTreeBuilder.parse(xml)
+      })
+
+      test('root element is fix', () => {
+        expect(doc.root.name).toBe('fix')
+      })
+
+      test('has major/minor version attributes', () => {
+        expect(doc.root.attribute('major')).toBeDefined()
+        expect(doc.root.attribute('minor')).toBeDefined()
+      })
+
+      test('has header section', () => {
+        const header = doc.firstDescendant('header')
+        expect(header).toBeDefined()
+        expect(header!.elements('field').length).toBeGreaterThan(0)
+      })
+
+      test('has trailer section', () => {
+        const trailer = doc.firstDescendant('trailer')
+        expect(trailer).toBeDefined()
+      })
+
+      test('has fields section with field definitions', () => {
+        const fields = doc.firstDescendant('fields')
+        expect(fields).toBeDefined()
+        const fieldNodes = fields!.elements('field')
+        expect(fieldNodes.length).toBeGreaterThan(100)
+        // Every field has name, number, type
+        fieldNodes.forEach(f => {
+          expect(f.attribute('name')).toBeDefined()
+          expect(f.attribute('number')).toBeDefined()
+          expect(f.attribute('type')).toBeDefined()
+        })
+      })
+
+      test('has components section', () => {
+        const components = doc.firstDescendant('components')
+        expect(components).toBeDefined()
+        const componentNodes = components!.elements('component')
+        // FIX 4.2 has no components — later versions do
+        componentNodes.forEach(c => {
+          expect(c.attribute('name')).toBeDefined()
+        })
+      })
+
+      test('has messages section', () => {
+        const messages = doc.firstDescendant('messages')
+        expect(messages).toBeDefined()
+        const messageNodes = messages!.elements('message')
+        expect(messageNodes.length).toBeGreaterThan(0)
+        // Every message has name and msgtype
+        messageNodes.forEach(m => {
+          expect(m.attribute('name')).toBeDefined()
+          expect(m.attribute('msgtype')).toBeDefined()
+        })
+      })
+
+      test('field definitions include enums as value children', () => {
+        const fields = doc.firstDescendant('fields')!
+        const fieldsWithEnums = fields.elements('field').filter(
+          f => f.elements('value').length > 0
+        )
+        expect(fieldsWithEnums.length).toBeGreaterThan(0)
+        // Enum values have enum and description attributes
+        const firstEnum = fieldsWithEnums[0].elements('value')[0]
+        expect(firstEnum.attribute('enum')).toBeDefined()
+        expect(firstEnum.attribute('description')).toBeDefined()
+      })
+
+      test('components contain nested groups', () => {
+        const allGroups = doc.descendants('group')
+        expect(allGroups.length).toBeGreaterThan(0)
+        // Groups have a name attribute
+        allGroups.forEach(g => {
+          expect(g.attribute('name')).toBeDefined()
+        })
+      })
+
+      test('descendants counts match elements traversal', () => {
+        const messagesSection = doc.firstDescendant('messages')!
+        const viaDescendants = doc.descendants('message').length
+        const viaElements = messagesSection.elements('message').length
+        // descendants finds messages only inside <messages>, so counts should match
+        expect(viaDescendants).toBe(viaElements)
+      })
+    })
+  })
+})
+
+describe('SaxTreeBuilder.parseStream', () => {
+  test('parse FIX44.xml from stream', async () => {
+    const filePath = path.join(dataRoot, 'FIX44.xml')
+    const stream = fs.createReadStream(filePath, 'utf-8')
+    const doc = await SaxTreeBuilder.parseStream(stream)
+    expect(doc.root.name).toBe('fix')
+    expect(doc.root.attribute('major')).toBe('4')
+    const fields = doc.firstDescendant('fields')
+    expect(fields).toBeDefined()
+    expect(fields!.elements('field').length).toBeGreaterThan(100)
+  })
+})


### PR DESCRIPTION
## Summary
- New `XElement` interface + `XDocument`/`XNode` query wrappers providing C#-style DOM access (`descendants()`, `elements()`, `attribute()`)
- `SaxTreeBuilder` builds the in-memory tree from a single SAX pass — both synchronous (`parse()`) and streaming (`parseStream()`)
- Foundation for Phase 6: graph-based QuickFix XML parser rework
- Expanded Phase 6 plan in BACKPORT_PLAN.md with 6 sub-PRs (6A–6F)
- No changes to existing parser code — new files only

## Test plan
- [x] 51 new tests: minimal XML, self-closing elements, nested structures, line tracking, `requiredAttribute` errors
- [x] Validates against all real FIX dictionaries (4.2, 4.3, 4.4, 5.0SP2)
- [x] Stream parsing test with FIX44.xml
- [x] All 443 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)