### PR TITLE
feat: add DictionaryValidator for pre-parse XML validation (PR 6B)

### DIFF
--- a/BACKPORT_PLAN.md
+++ b/BACKPORT_PLAN.md
@@ -285,27 +285,15 @@ interface XElement {
 
 #### PR 6A: XElement tree builder (new files only, zero risk)
 
-| File | Action |
-|------|--------|
-| New: `src/dictionary/parser/quickfix/x-element.ts` | `XElement` interface + `XDocument` wrapper with query methods (`descendants()`, `elements()`, `attribute()`) |
-| New: `src/dictionary/parser/quickfix/sax-tree-builder.ts` | Single SAX pass builds `XElement` tree from XML text/stream |
-| New: `src/test/dictionary/sax-tree-builder.test.ts` | Tests: parse FIX44.xml into tree, verify structure, query elements |
+### Status: **DONE** (PR #124)
 
-Query API should mirror C# `XDocument`/`XElement` for easy porting:
-- `descendants(name)` — all descendants with given tag name
-- `elements(name)` — direct children with given tag name  
-- `attribute(name)` — attribute value by name
+`XElement` interface + `XDocument`/`XNode` query wrappers + `SaxTreeBuilder` (single SAX pass → in-memory tree). 51 tests across all FIX dictionaries.
 
 #### PR 6B: DictionaryValidator (new files only, zero risk)
 
-| File | Action |
-|------|--------|
-| New: `src/dictionary/parser/quickfix/dictionary-validator.ts` | Port from C# — three-pass validation (collect, validate refs, check unused) |
-| New: `src/test/dictionary/dictionary-validator.test.ts` | Tests with valid and deliberately broken XML dictionaries |
+### Status: **DONE**
 
-Independent of 6A. Works against `XElement` tree (depends on 6A's `XDocument`).
-
-PRs 6A and 6B can be done **in parallel** once `XElement` interface is agreed.
+Three-pass validator ported from C#: collect definitions, validate references (with Levenshtein "did you mean" suggestions), check unused definitions. 40 tests including validation against all real FIX dictionaries.
 
 #### PR 6C: Graph-based parser — new implementation (medium risk)
 
@@ -370,8 +358,8 @@ PR 6F (Fix Trim) ──── after 6C is stable
 
 | PR | Risk | Reason |
 |----|------|--------|
-| 6A | None | New files only, SAX wrapper |
-| 6B | None | New files only, validation |
+| 6A | None | New files only, SAX wrapper — **DONE** (PR #124) |
+| 6B | None | New files only, validation — **DONE** |
 | 6C | Medium | New parser, but sits alongside old one — switchable |
 | 6D | Medium | Changes `ContainedSetBuilder` shared by all parsers |
 | 6E | HIGH | Switches default parser — must pass all tests across all FIX versions |

--- a/src/dictionary/parser/quickfix/dictionary-validator.ts
+++ b/src/dictionary/parser/quickfix/dictionary-validator.ts
@@ -1,0 +1,473 @@
+import { XDocument, XNode } from './x-element'
+import {
+  DictionaryValidationException,
+  ValidationError,
+  ValidationSeverity
+} from './validation-error'
+
+interface FieldDefinitionInfo {
+  readonly name: string
+  readonly tag: number
+  readonly type: string
+  readonly lineNumber?: number
+}
+
+interface ComponentDefinitionInfo {
+  readonly name: string
+  readonly lineNumber?: number
+}
+
+interface MessageDefinitionInfo {
+  readonly name: string
+  readonly msgType: string
+  readonly lineNumber?: number
+}
+
+/**
+ * Validates FIX dictionary XML for common errors like duplicates, missing references, etc.
+ * Port of C# DictionaryValidator — operates on an XDocument tree built by SaxTreeBuilder.
+ */
+export class DictionaryValidator {
+  private readonly _errors: ValidationError[] = []
+
+  // Track definitions — case-sensitive for exact matching
+  private readonly fieldsByName = new Map<string, FieldDefinitionInfo>()
+  private readonly fieldsByTag = new Map<number, FieldDefinitionInfo>()
+  private readonly componentsByName = new Map<string, ComponentDefinitionInfo>()
+  private readonly messagesByName = new Map<string, MessageDefinitionInfo>()
+  private readonly messagesByMsgType = new Map<string, MessageDefinitionInfo>()
+
+  // Case-insensitive lookup for "did you mean" suggestions
+  private readonly fieldNamesCaseInsensitive = new Map<string, string>()
+  private readonly componentNamesCaseInsensitive = new Map<string, string>()
+
+  // Track what's referenced (to find unused definitions)
+  private readonly referencedFields = new Set<string>()
+  private readonly referencedComponents = new Set<string>()
+
+  // All known names for "did you mean" suggestions
+  private readonly allFieldNames: string[] = []
+  private readonly allComponentNames: string[] = []
+
+  get errors (): ReadonlyArray<ValidationError> {
+    return this._errors
+  }
+
+  get hasErrors (): boolean {
+    return this._errors.some(e => e.severity === ValidationSeverity.Error)
+  }
+
+  get hasWarnings (): boolean {
+    return this._errors.some(e => e.severity === ValidationSeverity.Warning)
+  }
+
+  validate (doc: XDocument): void {
+    // First pass: collect all definitions
+    this.collectFieldDefinitions(doc)
+    this.collectComponentDefinitions(doc)
+    this.collectMessageDefinitions(doc)
+
+    // Second pass: validate references
+    this.validateHeader(doc)
+    this.validateTrailer(doc)
+    this.validateComponentReferences(doc)
+    this.validateMessageReferences(doc)
+
+    // Third pass: check for unused definitions (warnings only)
+    this.checkUnusedDefinitions()
+  }
+
+  throwIfErrors (): void {
+    if (this.hasErrors) {
+      throw new DictionaryValidationException(this._errors)
+    }
+  }
+
+  // ── Field Validation ──
+
+  private collectFieldDefinitions (doc: XDocument): void {
+    const fieldsNode = doc.firstDescendant('fields')
+    if (!fieldsNode) {
+      this.addError('MISSING_FIELDS', 'No <fields> section found in dictionary')
+      return
+    }
+
+    for (const field of fieldsNode.elements('field')) {
+      this.validateFieldDefinition(field)
+    }
+  }
+
+  private validateFieldDefinition (field: XNode): void {
+    const name = field.attribute('name')
+    const numberStr = field.attribute('number')
+    const type = field.attribute('type')
+    const lineNumber = field.line
+
+    if (!name) {
+      this.addError('FIELD_NO_NAME', 'Field definition missing \'name\' attribute', undefined, undefined, lineNumber)
+      return
+    }
+
+    const tag = numberStr != null ? parseInt(numberStr, 10) : NaN
+    if (!numberStr || isNaN(tag)) {
+      this.addError('FIELD_NO_TAG', `Field '${name}' missing or invalid 'number' attribute`, name, 'field', lineNumber)
+      return
+    }
+
+    if (!type) {
+      this.addWarning('FIELD_NO_TYPE', `Field '${name}' missing 'type' attribute, defaulting to STRING`, name, 'field', lineNumber)
+    }
+
+    this.allFieldNames.push(name)
+
+    // Check for duplicate by name
+    const existingByName = this.fieldsByName.get(name)
+    if (existingByName) {
+      this.addError('DUPLICATE_FIELD_NAME',
+        `Duplicate field name '${name}' (tag ${tag}). Previously defined with tag ${existingByName.tag}`,
+        name, 'field', lineNumber,
+        existingByName.tag === tag ? 'Remove the duplicate definition' : 'Use unique field names')
+      return
+    }
+
+    // Check for duplicate by tag
+    const existingByTag = this.fieldsByTag.get(tag)
+    if (existingByTag) {
+      this.addError('DUPLICATE_FIELD_TAG',
+        `Duplicate field tag ${tag} for '${name}'. Tag already used by field '${existingByTag.name}'`,
+        name, 'field', lineNumber,
+        'Each tag number must be unique')
+      return
+    }
+
+    const info: FieldDefinitionInfo = { name, tag, type: type ?? 'STRING', lineNumber }
+    this.fieldsByName.set(name, info)
+    this.fieldsByTag.set(tag, info)
+    this.fieldNamesCaseInsensitive.set(name.toLowerCase(), name)
+
+    this.validateFieldEnums(field, name, lineNumber)
+  }
+
+  private validateFieldEnums (field: XNode, fieldName: string, lineNumber?: number): void {
+    const values = field.elements('value')
+    if (values.length === 0) return
+
+    const seenEnumKeys = new Set<string>()
+    const seenEnumDescriptions = new Set<string>()
+
+    for (const value of values) {
+      const enumKey = value.attribute('enum')
+      const description = value.attribute('description')
+      const valueLine = value.line ?? lineNumber
+
+      if (!enumKey) {
+        this.addError('ENUM_NO_KEY', `Field '${fieldName}' has enum value without 'enum' attribute`,
+          fieldName, 'field', valueLine)
+        continue
+      }
+
+      if (!description) {
+        this.addWarning('ENUM_NO_DESC', `Field '${fieldName}' enum '${enumKey}' has no description`,
+          fieldName, 'field', valueLine)
+      }
+
+      if (seenEnumKeys.has(enumKey)) {
+        this.addError('DUPLICATE_ENUM_KEY',
+          `Field '${fieldName}' has duplicate enum key '${enumKey}'`,
+          fieldName, 'field', valueLine)
+      }
+      seenEnumKeys.add(enumKey)
+
+      if (description != null) {
+        const descLower = description.toLowerCase()
+        if (seenEnumDescriptions.has(descLower)) {
+          this.addWarning('DUPLICATE_ENUM_DESC',
+            `Field '${fieldName}' has duplicate enum description '${description}' which may cause naming conflicts`,
+            fieldName, 'field', valueLine)
+        }
+        seenEnumDescriptions.add(descLower)
+      }
+    }
+  }
+
+  // ── Component Validation ──
+
+  private collectComponentDefinitions (doc: XDocument): void {
+    const componentsNode = doc.firstDescendant('components')
+    if (!componentsNode) {
+      // Components are optional
+      return
+    }
+
+    for (const component of componentsNode.elements('component')) {
+      this.validateComponentDefinition(component)
+    }
+  }
+
+  private validateComponentDefinition (component: XNode): void {
+    const name = component.attribute('name')
+    const lineNumber = component.line
+
+    if (!name) {
+      this.addError('COMPONENT_NO_NAME', 'Component definition missing \'name\' attribute', undefined, undefined, lineNumber)
+      return
+    }
+
+    this.allComponentNames.push(name)
+
+    const existing = this.componentsByName.get(name)
+    if (existing) {
+      this.addError('DUPLICATE_COMPONENT',
+        `Duplicate component name '${name}'`,
+        name, 'component', lineNumber,
+        `Previously defined at line ${existing.lineNumber ?? '?'}`)
+      return
+    }
+
+    this.componentsByName.set(name, { name, lineNumber })
+    this.componentNamesCaseInsensitive.set(name.toLowerCase(), name)
+
+    this.validateFieldReferences(component, name, 'component')
+  }
+
+  // ── Message Validation ──
+
+  private collectMessageDefinitions (doc: XDocument): void {
+    const messagesNode = doc.firstDescendant('messages')
+    if (!messagesNode) {
+      this.addError('MISSING_MESSAGES', 'No <messages> section found in dictionary')
+      return
+    }
+
+    for (const message of messagesNode.elements('message')) {
+      this.validateMessageDefinition(message)
+    }
+  }
+
+  private validateMessageDefinition (message: XNode): void {
+    const name = message.attribute('name')
+    const msgType = message.attribute('msgtype')
+    const lineNumber = message.line
+
+    if (!name) {
+      this.addError('MESSAGE_NO_NAME', 'Message definition missing \'name\' attribute', undefined, undefined, lineNumber)
+      return
+    }
+
+    if (!msgType) {
+      this.addError('MESSAGE_NO_MSGTYPE', `Message '${name}' missing 'msgtype' attribute`,
+        name, 'message', lineNumber)
+      return
+    }
+
+    const existingByName = this.messagesByName.get(name)
+    if (existingByName) {
+      this.addError('DUPLICATE_MESSAGE_NAME',
+        `Duplicate message name '${name}'`,
+        name, 'message', lineNumber,
+        `Previously defined at line ${existingByName.lineNumber ?? '?'}`)
+      return
+    }
+
+    const existingByType = this.messagesByMsgType.get(msgType)
+    if (existingByType) {
+      this.addError('DUPLICATE_MESSAGE_TYPE',
+        `Duplicate message type '${msgType}' for message '${name}'. Type already used by '${existingByType.name}'`,
+        name, 'message', lineNumber)
+      return
+    }
+
+    const info: MessageDefinitionInfo = { name, msgType, lineNumber }
+    this.messagesByName.set(name, info)
+    this.messagesByMsgType.set(msgType, info)
+
+    this.validateFieldReferences(message, name, 'message')
+  }
+
+  // ── Reference Validation ──
+
+  private validateHeader (doc: XDocument): void {
+    const header = doc.firstDescendant('header')
+    if (!header) {
+      this.addError('MISSING_HEADER', 'No <header> section found in dictionary')
+      return
+    }
+    this.validateFieldReferences(header, 'StandardHeader', 'header')
+  }
+
+  private validateTrailer (doc: XDocument): void {
+    const trailer = doc.firstDescendant('trailer')
+    if (!trailer) {
+      this.addError('MISSING_TRAILER', 'No <trailer> section found in dictionary')
+      return
+    }
+    this.validateFieldReferences(trailer, 'StandardTrailer', 'trailer')
+  }
+
+  private validateComponentReferences (doc: XDocument): void {
+    const componentsNode = doc.firstDescendant('components')
+    if (!componentsNode) return
+
+    for (const component of componentsNode.elements('component')) {
+      const name = component.attribute('name')
+      if (!name) continue
+
+      for (const compRef of component.descendants('component')) {
+        this.validateComponentReference(compRef, name, 'component')
+      }
+    }
+  }
+
+  private validateMessageReferences (doc: XDocument): void {
+    const messagesNode = doc.firstDescendant('messages')
+    if (!messagesNode) return
+
+    for (const message of messagesNode.elements('message')) {
+      const name = message.attribute('name')
+      if (!name) continue
+
+      for (const compRef of message.descendants('component')) {
+        this.validateComponentReference(compRef, name, 'message')
+      }
+    }
+  }
+
+  private validateFieldReferences (container: XNode, containerName: string, containerType: string): void {
+    for (const fieldRef of container.elements('field')) {
+      const fieldName = fieldRef.attribute('name')
+      const lineNumber = fieldRef.line
+
+      if (!fieldName) {
+        this.addError('FIELD_REF_NO_NAME',
+          `Field reference in ${containerType} '${containerName}' missing 'name' attribute`,
+          containerName, containerType, lineNumber)
+        continue
+      }
+
+      this.referencedFields.add(fieldName)
+
+      if (!this.fieldsByName.has(fieldName)) {
+        // Check for case mismatch first
+        const correctCase = this.fieldNamesCaseInsensitive.get(fieldName.toLowerCase())
+        const suggestion = correctCase ?? DictionaryValidator.findSimilar(fieldName, this.allFieldNames)
+
+        this.addError('UNDEFINED_FIELD',
+          `Field '${fieldName}' referenced in ${containerType} '${containerName}' is not defined`,
+          fieldName, 'field reference', lineNumber,
+          suggestion != null ? `Did you mean '${suggestion}'?` : 'Add the field to the <fields> section')
+      }
+    }
+
+    // Recursively check groups
+    for (const group of container.elements('group')) {
+      const groupName = group.attribute('name') ?? 'unknown'
+      this.referencedFields.add(groupName)
+
+      if (groupName !== 'unknown' && !this.fieldsByName.has(groupName)) {
+        const lineNumber = group.line
+        const suggestion = DictionaryValidator.findSimilar(groupName, this.allFieldNames)
+
+        this.addError('UNDEFINED_GROUP_FIELD',
+          `Group '${groupName}' in ${containerType} '${containerName}' has no corresponding field definition (for the repeating count)`,
+          groupName, 'group', lineNumber,
+          suggestion != null ? `Did you mean '${suggestion}'?` : 'Add a NUMINGROUP field for this group')
+      }
+
+      this.validateFieldReferences(group, `${containerName}.${groupName}`, 'group')
+    }
+  }
+
+  private validateComponentReference (compRef: XNode, containerName: string, containerType: string): void {
+    const compName = compRef.attribute('name')
+    const lineNumber = compRef.line
+
+    if (!compName) {
+      this.addError('COMPONENT_REF_NO_NAME',
+        `Component reference in ${containerType} '${containerName}' missing 'name' attribute`,
+        containerName, containerType, lineNumber)
+      return
+    }
+
+    this.referencedComponents.add(compName)
+
+    if (!this.componentsByName.has(compName) &&
+        compName !== 'StandardHeader' && compName !== 'StandardTrailer') {
+      const suggestion = DictionaryValidator.findSimilar(compName, this.allComponentNames)
+      this.addError('UNDEFINED_COMPONENT',
+        `Component '${compName}' referenced in ${containerType} '${containerName}' is not defined`,
+        compName, 'component reference', lineNumber,
+        suggestion != null ? `Did you mean '${suggestion}'?` : 'Add the component to the <components> section')
+    }
+  }
+
+  private checkUnusedDefinitions (): void {
+    for (const field of this.fieldsByName.values()) {
+      if (!this.referencedFields.has(field.name)) {
+        this.addWarning('UNUSED_FIELD',
+          `Field '${field.name}' (tag ${field.tag}) is defined but never referenced`,
+          field.name, 'field', field.lineNumber)
+      }
+    }
+
+    for (const comp of this.componentsByName.values()) {
+      if (!this.referencedComponents.has(comp.name)) {
+        this.addWarning('UNUSED_COMPONENT',
+          `Component '${comp.name}' is defined but never referenced`,
+          comp.name, 'component', comp.lineNumber)
+      }
+    }
+  }
+
+  // ── Helpers ──
+
+  private addError (code: string, message: string, elementName?: string,
+    elementType?: string, lineNumber?: number, suggestion?: string): void {
+    this._errors.push({ severity: ValidationSeverity.Error, code, message, elementName, elementType, lineNumber, suggestion })
+  }
+
+  private addWarning (code: string, message: string, elementName?: string,
+    elementType?: string, lineNumber?: number, suggestion?: string): void {
+    this._errors.push({ severity: ValidationSeverity.Warning, code, message, elementName, elementType, lineNumber, suggestion })
+  }
+
+  static findSimilar (input: string, candidates: string[]): string | null {
+    let bestMatch: string | null = null
+    let bestDistance = Infinity
+    const maxDistance = Math.max(3, Math.floor(input.length / 2))
+    const inputLower = input.toLowerCase()
+
+    for (const candidate of candidates) {
+      const distance = DictionaryValidator.levenshteinDistance(inputLower, candidate.toLowerCase())
+      if (distance < bestDistance && distance <= maxDistance) {
+        bestDistance = distance
+        bestMatch = candidate
+      }
+    }
+
+    return bestMatch
+  }
+
+  static levenshteinDistance (s1: string, s2: string): number {
+    const n = s1.length
+    const m = s2.length
+    if (n === 0) return m
+    if (m === 0) return n
+
+    const d: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0))
+
+    for (let i = 0; i <= n; i++) d[i][0] = i
+    for (let j = 0; j <= m; j++) d[0][j] = j
+
+    for (let i = 1; i <= n; i++) {
+      for (let j = 1; j <= m; j++) {
+        const cost = s1[i - 1] === s2[j - 1] ? 0 : 1
+        d[i][j] = Math.min(
+          d[i - 1][j] + 1,
+          d[i][j - 1] + 1,
+          d[i - 1][j - 1] + cost)
+      }
+    }
+
+    return d[n][m]
+  }
+}

--- a/src/dictionary/parser/quickfix/index.ts
+++ b/src/dictionary/parser/quickfix/index.ts
@@ -1,3 +1,5 @@
 export * from './quick-fix-xml-file-parser'
 export * from './x-element'
 export * from './sax-tree-builder'
+export * from './dictionary-validator'
+export * from './validation-error'

--- a/src/dictionary/parser/quickfix/validation-error.ts
+++ b/src/dictionary/parser/quickfix/validation-error.ts
@@ -1,0 +1,34 @@
+export enum ValidationSeverity {
+  Warning = 'Warning',
+  Error = 'Error'
+}
+
+export interface ValidationError {
+  readonly severity: ValidationSeverity
+  readonly code: string
+  readonly message: string
+  readonly elementName?: string
+  readonly elementType?: string
+  readonly lineNumber?: number
+  readonly suggestion?: string
+}
+
+export class DictionaryValidationException extends Error {
+  constructor (public readonly errors: ReadonlyArray<ValidationError>) {
+    const errorCount = errors.filter(e => e.severity === ValidationSeverity.Error).length
+    const warningCount = errors.filter(e => e.severity === ValidationSeverity.Warning).length
+    const header = `FIX dictionary validation failed with ${errorCount} error(s) and ${warningCount} warning(s):`
+    const details = errors
+      .filter(e => e.severity === ValidationSeverity.Error)
+      .slice(0, 20)
+      .map(e => {
+        let line = `  [${e.code}] ${e.message}`
+        if (e.lineNumber != null) line += ` (line ${e.lineNumber})`
+        if (e.suggestion) line += ` — ${e.suggestion}`
+        return line
+      })
+      .join('\n')
+    super(`${header}\n${details}`)
+    this.name = 'DictionaryValidationException'
+  }
+}

--- a/src/test/dictionary/dictionary-validator.test.ts
+++ b/src/test/dictionary/dictionary-validator.test.ts
@@ -1,0 +1,422 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { SaxTreeBuilder } from '../../dictionary/parser/quickfix/sax-tree-builder'
+import { DictionaryValidator } from '../../dictionary/parser/quickfix/dictionary-validator'
+import { ValidationSeverity, DictionaryValidationException } from '../../dictionary/parser/quickfix/validation-error'
+
+const dataRoot = path.join(__dirname, '../../../data')
+
+function validate (xml: string): DictionaryValidator {
+  const doc = SaxTreeBuilder.parse(xml)
+  const validator = new DictionaryValidator()
+  validator.validate(doc)
+  return validator
+}
+
+function errorsWithCode (validator: DictionaryValidator, code: string) {
+  return validator.errors.filter(e => e.code === code)
+}
+
+const validMinimalXml = `
+<fix major="4" minor="4">
+  <header>
+    <field name="BeginString" required="Y" />
+    <field name="MsgType" required="Y" />
+  </header>
+  <trailer>
+    <field name="CheckSum" required="Y" />
+  </trailer>
+  <messages>
+    <message name="Heartbeat" msgtype="0" msgcat="admin">
+      <field name="TestReqID" required="N" />
+    </message>
+  </messages>
+  <components />
+  <fields>
+    <field number="8" name="BeginString" type="STRING" />
+    <field number="10" name="CheckSum" type="STRING" />
+    <field number="35" name="MsgType" type="STRING" />
+    <field number="112" name="TestReqID" type="STRING" />
+  </fields>
+</fix>`
+
+describe('DictionaryValidator — valid dictionaries', () => {
+  test('minimal valid dictionary has no errors', () => {
+    const v = validate(validMinimalXml)
+    expect(v.hasErrors).toBe(false)
+  })
+
+  test('minimal valid dictionary may have unused field warnings', () => {
+    // All fields are referenced, so no warnings either
+    const v = validate(validMinimalXml)
+    const unused = errorsWithCode(v, 'UNUSED_FIELD')
+    expect(unused.length).toBe(0)
+  })
+})
+
+describe('DictionaryValidator — missing sections', () => {
+  test('missing fields section', () => {
+    const v = validate('<fix><header /><trailer /><messages /><components /></fix>')
+    expect(errorsWithCode(v, 'MISSING_FIELDS').length).toBe(1)
+  })
+
+  test('missing messages section', () => {
+    const v = validate('<fix><header /><trailer /><fields /><components /></fix>')
+    expect(errorsWithCode(v, 'MISSING_MESSAGES').length).toBe(1)
+  })
+
+  test('missing header section', () => {
+    const v = validate('<fix><trailer /><messages /><fields /><components /></fix>')
+    expect(errorsWithCode(v, 'MISSING_HEADER').length).toBe(1)
+  })
+
+  test('missing trailer section', () => {
+    const v = validate('<fix><header /><messages /><fields /><components /></fix>')
+    expect(errorsWithCode(v, 'MISSING_TRAILER').length).toBe(1)
+  })
+})
+
+describe('DictionaryValidator — field definition errors', () => {
+  test('field missing name', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields><field number="1" type="STRING" /></fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'FIELD_NO_NAME').length).toBe(1)
+  })
+
+  test('field missing number', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields><field name="Account" type="STRING" /></fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'FIELD_NO_TAG').length).toBe(1)
+  })
+
+  test('field missing type is warning', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields><field name="Account" number="1" /></fields></fix>`
+    const v = validate(xml)
+    const warnings = errorsWithCode(v, 'FIELD_NO_TYPE')
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].severity).toBe(ValidationSeverity.Warning)
+  })
+
+  test('duplicate field name', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Account" number="1" type="STRING" />
+        <field name="Account" number="2" type="STRING" />
+      </fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_FIELD_NAME').length).toBe(1)
+  })
+
+  test('duplicate field tag', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Account" number="1" type="STRING" />
+        <field name="AdvId" number="1" type="STRING" />
+      </fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_FIELD_TAG').length).toBe(1)
+  })
+})
+
+describe('DictionaryValidator — enum errors', () => {
+  test('enum missing key', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Side" number="54" type="CHAR">
+          <value description="Buy" />
+        </field>
+      </fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'ENUM_NO_KEY').length).toBe(1)
+  })
+
+  test('enum missing description is warning', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Side" number="54" type="CHAR">
+          <value enum="1" />
+        </field>
+      </fields></fix>`
+    const v = validate(xml)
+    const warnings = errorsWithCode(v, 'ENUM_NO_DESC')
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].severity).toBe(ValidationSeverity.Warning)
+  })
+
+  test('duplicate enum key', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Side" number="54" type="CHAR">
+          <value enum="1" description="Buy" />
+          <value enum="1" description="Sell" />
+        </field>
+      </fields></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_ENUM_KEY').length).toBe(1)
+  })
+
+  test('duplicate enum description is warning', () => {
+    const xml = `<fix><header /><trailer /><messages /><components />
+      <fields>
+        <field name="Side" number="54" type="CHAR">
+          <value enum="1" description="Buy" />
+          <value enum="2" description="Buy" />
+        </field>
+      </fields></fix>`
+    const v = validate(xml)
+    const warnings = errorsWithCode(v, 'DUPLICATE_ENUM_DESC')
+    expect(warnings.length).toBe(1)
+    expect(warnings[0].severity).toBe(ValidationSeverity.Warning)
+  })
+})
+
+describe('DictionaryValidator — component errors', () => {
+  test('component missing name', () => {
+    const xml = `<fix><header /><trailer /><messages />
+      <fields />
+      <components><component /></components></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'COMPONENT_NO_NAME').length).toBe(1)
+  })
+
+  test('duplicate component name', () => {
+    const xml = `<fix><header /><trailer /><messages />
+      <fields />
+      <components>
+        <component name="Instrument" />
+        <component name="Instrument" />
+      </components></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_COMPONENT').length).toBe(1)
+  })
+})
+
+describe('DictionaryValidator — message errors', () => {
+  test('message missing name', () => {
+    const xml = `<fix><header /><trailer /><fields /><components />
+      <messages><message msgtype="0" /></messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'MESSAGE_NO_NAME').length).toBe(1)
+  })
+
+  test('message missing msgtype', () => {
+    const xml = `<fix><header /><trailer /><fields /><components />
+      <messages><message name="Heartbeat" /></messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'MESSAGE_NO_MSGTYPE').length).toBe(1)
+  })
+
+  test('duplicate message name', () => {
+    const xml = `<fix><header /><trailer /><fields /><components />
+      <messages>
+        <message name="Heartbeat" msgtype="0" />
+        <message name="Heartbeat" msgtype="1" />
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_MESSAGE_NAME').length).toBe(1)
+  })
+
+  test('duplicate message type', () => {
+    const xml = `<fix><header /><trailer /><fields /><components />
+      <messages>
+        <message name="Heartbeat" msgtype="0" />
+        <message name="TestRequest" msgtype="0" />
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'DUPLICATE_MESSAGE_TYPE').length).toBe(1)
+  })
+})
+
+describe('DictionaryValidator — reference errors', () => {
+  test('undefined field reference', () => {
+    const xml = `<fix><header /><trailer />
+      <fields>
+        <field name="BeginString" number="8" type="STRING" />
+      </fields>
+      <components />
+      <messages>
+        <message name="Heartbeat" msgtype="0">
+          <field name="NonExistent" required="N" />
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'UNDEFINED_FIELD').length).toBe(1)
+  })
+
+  test('undefined field suggests similar name', () => {
+    const xml = `<fix><header /><trailer />
+      <fields>
+        <field name="Account" number="1" type="STRING" />
+      </fields>
+      <components />
+      <messages>
+        <message name="Order" msgtype="D">
+          <field name="Acount" required="Y" />
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    const err = errorsWithCode(v, 'UNDEFINED_FIELD')[0]
+    expect(err.suggestion).toContain('Account')
+  })
+
+  test('undefined component reference', () => {
+    const xml = `<fix><header /><trailer />
+      <fields />
+      <components />
+      <messages>
+        <message name="Order" msgtype="D">
+          <component name="NonExistent" required="N" />
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'UNDEFINED_COMPONENT').length).toBe(1)
+  })
+
+  test('StandardHeader and StandardTrailer are exempt from component check', () => {
+    const xml = `<fix><header /><trailer />
+      <fields />
+      <components />
+      <messages>
+        <message name="Order" msgtype="D">
+          <component name="StandardHeader" required="Y" />
+          <component name="StandardTrailer" required="Y" />
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'UNDEFINED_COMPONENT').length).toBe(0)
+  })
+
+  test('undefined group counter field', () => {
+    const xml = `<fix><header /><trailer />
+      <fields>
+        <field name="RefMsgType" number="372" type="STRING" />
+      </fields>
+      <components />
+      <messages>
+        <message name="Logon" msgtype="A">
+          <group name="NoMsgTypes" required="N">
+            <field name="RefMsgType" required="N" />
+          </group>
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'UNDEFINED_GROUP_FIELD').length).toBe(1)
+  })
+
+  test('group with defined counter field passes', () => {
+    const xml = `<fix><header /><trailer />
+      <fields>
+        <field name="NoMsgTypes" number="384" type="NUMINGROUP" />
+        <field name="RefMsgType" number="372" type="STRING" />
+      </fields>
+      <components />
+      <messages>
+        <message name="Logon" msgtype="A">
+          <group name="NoMsgTypes" required="N">
+            <field name="RefMsgType" required="N" />
+          </group>
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    expect(errorsWithCode(v, 'UNDEFINED_GROUP_FIELD').length).toBe(0)
+  })
+})
+
+describe('DictionaryValidator — unused definitions', () => {
+  test('unused field generates warning', () => {
+    const xml = `<fix><header /><trailer />
+      <fields>
+        <field name="Account" number="1" type="STRING" />
+        <field name="UnusedField" number="999" type="STRING" />
+      </fields>
+      <components />
+      <messages>
+        <message name="Order" msgtype="D">
+          <field name="Account" required="Y" />
+        </message>
+      </messages></fix>`
+    const v = validate(xml)
+    const unused = errorsWithCode(v, 'UNUSED_FIELD')
+    expect(unused.length).toBe(1)
+    expect(unused[0].elementName).toBe('UnusedField')
+    expect(unused[0].severity).toBe(ValidationSeverity.Warning)
+  })
+
+  test('unused component generates warning', () => {
+    const xml = `<fix><header /><trailer />
+      <fields />
+      <components>
+        <component name="UnusedComp" />
+      </components>
+      <messages /></fix>`
+    const v = validate(xml)
+    const unused = errorsWithCode(v, 'UNUSED_COMPONENT')
+    expect(unused.length).toBe(1)
+    expect(unused[0].elementName).toBe('UnusedComp')
+    expect(unused[0].severity).toBe(ValidationSeverity.Warning)
+  })
+})
+
+describe('DictionaryValidator — throwIfErrors', () => {
+  test('throws DictionaryValidationException on errors', () => {
+    const v = validate('<fix></fix>')
+    expect(v.hasErrors).toBe(true)
+    expect(() => v.throwIfErrors()).toThrow(DictionaryValidationException)
+  })
+
+  test('does not throw when only warnings', () => {
+    const v = validate(validMinimalXml)
+    expect(v.hasErrors).toBe(false)
+    expect(() => v.throwIfErrors()).not.toThrow()
+  })
+})
+
+describe('DictionaryValidator — Levenshtein distance', () => {
+  test('identical strings', () => {
+    expect(DictionaryValidator.levenshteinDistance('abc', 'abc')).toBe(0)
+  })
+
+  test('single edit', () => {
+    expect(DictionaryValidator.levenshteinDistance('abc', 'abd')).toBe(1)
+  })
+
+  test('empty strings', () => {
+    expect(DictionaryValidator.levenshteinDistance('', 'abc')).toBe(3)
+    expect(DictionaryValidator.levenshteinDistance('abc', '')).toBe(3)
+  })
+
+  test('findSimilar returns closest match', () => {
+    const candidates = ['Account', 'Symbol', 'Side', 'OrderQty']
+    expect(DictionaryValidator.findSimilar('Acount', candidates)).toBe('Account')
+    expect(DictionaryValidator.findSimilar('Symbl', candidates)).toBe('Symbol')
+  })
+
+  test('findSimilar returns null for no close match', () => {
+    const candidates = ['Account', 'Symbol']
+    expect(DictionaryValidator.findSimilar('XyzAbc', candidates)).toBeNull()
+  })
+})
+
+describe('DictionaryValidator — real FIX dictionaries', () => {
+  const fixFiles = ['FIX42.xml', 'FIX43.xml', 'FIX44.xml', 'FIX50SP2.xml']
+
+  fixFiles.forEach(file => {
+    const filePath = path.join(dataRoot, file)
+    if (!fs.existsSync(filePath)) return
+
+    test(`${file} has no errors`, () => {
+      const xml = fs.readFileSync(filePath, 'utf-8')
+      const doc = SaxTreeBuilder.parse(xml)
+      const validator = new DictionaryValidator()
+      validator.validate(doc)
+      const errors = validator.errors.filter(e => e.severity === ValidationSeverity.Error)
+      if (errors.length > 0) {
+        console.log(`${file} errors:`, errors.slice(0, 5).map(e => `[${e.code}] ${e.message}`))
+      }
+      expect(errors.length).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Port of C# `DictionaryValidator` — three-pass validation against `XDocument` tree
- **Pass 1 (collect)**: field definitions (name, tag, type, enums), components, messages — checks for duplicates
- **Pass 2 (validate)**: field/component references in header, trailer, components, messages, and groups — with Levenshtein "did you mean" suggestions for typos
- **Pass 3 (unused)**: warns on unreferenced fields and components
- `ValidationError` records with severity, code, line number, and suggestion
- `DictionaryValidationException` for programmatic error handling
- New files only, no changes to existing parser code

## Test plan
- [x] 40 new tests covering all error codes: missing sections, field/component/message duplicates, enum errors, undefined references, unused definitions, Levenshtein suggestions
- [x] Validates against all real FIX dictionaries (4.2, 4.3, 4.4, 5.0SP2) — zero errors
- [x] All 483 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)