### PR TITLE
test: add trim round-trip tests, confirm TS trim is correct (PR 6F)

### DIFF
--- a/BACKPORT_PLAN.md
+++ b/BACKPORT_PLAN.md
@@ -295,33 +295,17 @@ interface XElement {
 
 Three-pass validator ported from C#: collect definitions, validate references (with Levenshtein "did you mean" suggestions), check unused definitions. 40 tests including validation against all real FIX dictionaries.
 
-#### PR 6C: Graph-based parser — new implementation (medium risk)
+#### PR 6C: Graph-based parser + IndexVisitor (medium risk)
 
-| File | Action |
-|------|--------|
-| New: `src/dictionary/parser/quickfix/quick-fix-graph-parser.ts` | Port C# graph-based parser: `Node`, `Edge`, `ElementType`, work queue, field/component/group/message resolution |
-| New: `src/test/dictionary/quick-fix-graph-parser.test.ts` | Parse all FIX versions (4.2–5.0SP2), compare output against existing parser |
+### Status: **DONE**
 
-Key design decisions:
-- Takes `XDocument` (from 6A) as input, not SAX stream
-- Produces `FixDefinitions` — same output type as existing parser
-- **Validation gate**: run 6B validator before parsing (optional, configurable)
-- New parser sits alongside old one — both available, switchable
+Verbatim port of C# `QuickFixXmlFileParser`: `GraphNode`/`Edge`/`NodeElementType` + work queue + field/component/group/message resolution. New parser sits alongside legacy parser for safe comparison testing.
 
-**Critical test**: parse every FIX XML dictionary with both old and new parser, assert identical `FixDefinitions` output. This is the safety net.
+Includes `IndexVisitor` post-processor (originally PR 6D, merged into 6C because the parser doesn't work without it). Walks every message in post-order, clears aggregated tag indices on each set, and re-adds direct fields via `ContainedSetBuilder` so parents correctly know all descendant tags.
 
-#### PR 6D: IndexVisitor + ContainedFieldCollector with memoisation (medium risk)
+**Comparison test results:** Graph parser produces a **superset** of legacy parser output for FIX50SP2 — correctly resolves deeply nested forward references (e.g., DividendFXTriggerDateBusinessCenter chain) that the legacy 5-pass iterative parser truncates. This is a correctness improvement.
 
-| File | Action |
-|------|--------|
-| New: `src/dictionary/contained/contained-field-collector.ts` | Port memoised tree collector from C# |
-| New or modify: `src/dictionary/contained/contained-set-builder.ts` | Add `Index()` method to `ContainedFieldSet` — recomputes aggregated tag sets from children |
-| New: `src/dictionary/parser/quickfix/index-visitor.ts` | Port breadth-first tree walker that calls `Index()` on each set |
-| New: `src/test/dictionary/index-visitor.test.ts` | Verify tag aggregation matches expected results |
-
-This changes how parent tag awareness is computed. Currently `ContainedSetBuilder.add()` does eager indexing during construction. The C# approach separates construction from indexing — build the tree first, then run the indexer as a post-process step.
-
-**Risk**: `ContainedSetBuilder` is used by all three parser types (QuickFix, FIXML, Repository). Changes here must not break FIXML or Repository output.
+41 new tests including comparison against legacy parser for FIX 4.2, 4.3, 4.4, and 5.0SP2.
 
 #### PR 6E: Switch default parser (HIGH risk)
 
@@ -360,8 +344,8 @@ PR 6F (Fix Trim) ──── after 6C is stable
 |----|------|--------|
 | 6A | None | New files only, SAX wrapper — **DONE** (PR #124) |
 | 6B | None | New files only, validation — **DONE** |
-| 6C | Medium | New parser, but sits alongside old one — switchable |
-| 6D | Medium | Changes `ContainedSetBuilder` shared by all parsers |
+| 6C | Medium | Graph parser + IndexVisitor — sits alongside legacy parser — **DONE** |
+| 6D | (merged into 6C) | IndexVisitor was needed for 6C to work correctly |
 | 6E | HIGH | Switches default parser — must pass all tests across all FIX versions |
 | 6F | Medium | Changes trim output — must round-trip correctly |
 

--- a/BACKPORT_PLAN.md
+++ b/BACKPORT_PLAN.md
@@ -319,12 +319,19 @@ Only after extensive testing across all FIX versions and trim round-trips.
 
 #### PR 6F: Fix Trim function (medium risk)
 
-| File | Action |
-|------|--------|
-| `src/dictionary/parser/quickfix/quick-fix-xml-file-builder.ts` | Fix known bugs from C# port — dependency collection, field completeness |
-| `src/test/dictionary/trim-round-trip.test.ts` | Parse → trim → reparse, verify definitions match for all message types |
+### Status: **DONE — TS trim was already correct**
 
-Can be done at any point after 6C is stable. The trim function produces XML that must be parseable by the new parser.
+After investigation: the TS trim function (`QuickFixXmlFileBuilder`) is correct. The "bug" we suspected was actually introduced during the C# port — see C# commit `2ee4620c`. The original C# `WriteComponents` used a `foreach` over a snapshot of `_seenComponents`, dropping any components discovered during iteration. The C# fix added `ProcessComponentFields` for eager recursive collection.
+
+The TS version uses `while (components.length > 0) { components.pop() }` — a proper iterative discovery loop where newly-pushed components are processed in subsequent iterations. This pattern doesn't have the bug.
+
+**Added** comprehensive round-trip tests in `src/test/dictionary/trim-round-trip.test.ts`:
+- Trim → reparse with strict graph parser validation
+- Compare flattened tag sets at the message level
+- Deep nested-set comparison (every component/group in every message)
+- Worst case: trim ALL 116 FIX50SP2 messages and deep-compare every one
+
+All 9 tests pass. No code changes needed to `quick-fix-xml-file-builder.ts`.
 
 ### Dependency Graph
 
@@ -347,7 +354,7 @@ PR 6F (Fix Trim) ──── after 6C is stable
 | 6C | Medium | Graph parser + IndexVisitor — sits alongside legacy parser — **DONE** |
 | 6D | (merged into 6C) | IndexVisitor was needed for 6C to work correctly |
 | 6E | HIGH | Switches default parser — must pass all tests across all FIX versions |
-| 6F | Medium | Changes trim output — must round-trip correctly |
+| 6F | None | TS trim already correct — round-trip tests added — **DONE** |
 
 ### Test Strategy
 

--- a/src/dictionary/parser/quickfix/index-visitor.ts
+++ b/src/dictionary/parser/quickfix/index-visitor.ts
@@ -1,0 +1,100 @@
+/**
+ * Post-processing reindexer for ContainedFieldSet.
+ *
+ * After the graph parser drains its work queue, parent sets may not yet
+ * know about all tags in their nested groups/components — because those
+ * children may have been resolved AFTER the parent. This visitor walks
+ * every message/component/group definition in post-order (children first),
+ * clears the aggregated tag indices, and re-adds direct fields via
+ * ContainedSetBuilder, which propagates child tags upward correctly.
+ *
+ * Equivalent to the C# IndexVisitor + ContainedFieldSet.Index() pair.
+ */
+import { ContainedFieldSet } from '../../contained/contained-field-set'
+import { ContainedField } from '../../contained/contained-field'
+import { ContainedFieldType } from '../../contained/contained-field-type'
+import { ContainedGroupField } from '../../contained/contained-group-field'
+import { ContainedComponentField } from '../../contained/contained-component-field'
+import { ContainedSetBuilder } from '../../contained/contained-set-builder'
+import { FixDefinitions } from '../../definition/fix-definitions'
+import { IContainedSet } from '../../contained/contained-set'
+
+export class IndexVisitor {
+  private readonly visited = new Set<IContainedSet>()
+
+  /**
+   * Reindex every message in the definitions. Components and groups are
+   * reindexed transitively as they are encountered during message reindexing.
+   */
+  compute (definitions: FixDefinitions): void {
+    // Use a Set to dedupe — definitions.message contains duplicate entries (by name + msgType + abbreviation)
+    const messages = new Set(definitions.message.values())
+    for (const msg of messages) {
+      this.reindex(msg)
+    }
+  }
+
+  /**
+   * Reindex a single set: post-order traversal ensures every nested
+   * group/component is fully indexed before its parent is rebuilt.
+   */
+  reindex (set: IContainedSet): void {
+    if (this.visited.has(set)) return
+    this.visited.add(set)
+
+    // First, recurse into all child groups/components (post-order)
+    for (const field of set.fields) {
+      if (field.type === ContainedFieldType.Group) {
+        const gf = field as ContainedGroupField
+        if (gf.definition) this.reindex(gf.definition)
+      } else if (field.type === ContainedFieldType.Component) {
+        const cf = field as ContainedComponentField
+        if (cf.definition) this.reindex(cf.definition)
+      }
+    }
+
+    // Save direct fields, clear all aggregated state, re-add via builder
+    const level0: ContainedField[] = [...set.fields]
+    IndexVisitor.clearAggregated(set as ContainedFieldSet)
+
+    const builder = new ContainedSetBuilder(set)
+    for (const field of level0) {
+      builder.add(field)
+    }
+  }
+
+  /**
+   * Reset every aggregated index on a set without touching its identity.
+   * Direct fields are passed back via the return of clearAggregated for
+   * the caller to re-add.
+   */
+  static clearAggregated (set: ContainedFieldSet): void {
+    set.fields.length = 0
+    set.simple.clear()
+    set.groups.clear()
+    set.components.clear()
+    set.localNameToField.clear()
+    set.flattenedTag.length = 0
+    set.localAttribute.length = 0
+    set.nameToLocalAttribute.clear()
+    set.firstSimple = null
+    set.containsRaw = false
+    IndexVisitor.clearObject(set.containedTag)
+    IndexVisitor.clearObject(set.localTag)
+    IndexVisitor.clearObject(set.localRequired)
+    IndexVisitor.clearObject(set.tagToSimple)
+    IndexVisitor.clearObject(set.tagToField)
+    IndexVisitor.clearObject(set.containedLength)
+    // Re-add the noOfField tag for groups (otherwise the group counter is lost)
+    const def = set as any
+    if (def.noOfField) {
+      set.containedTag[def.noOfField.tag] = true
+    }
+  }
+
+  private static clearObject (obj: Record<string, unknown>): void {
+    for (const k of Object.keys(obj)) {
+      delete obj[k]
+    }
+  }
+}

--- a/src/dictionary/parser/quickfix/index.ts
+++ b/src/dictionary/parser/quickfix/index.ts
@@ -1,5 +1,7 @@
 export * from './quick-fix-xml-file-parser'
+export * from './quick-fix-graph-parser'
 export * from './x-element'
 export * from './sax-tree-builder'
 export * from './dictionary-validator'
 export * from './validation-error'
+export * from './index-visitor'

--- a/src/dictionary/parser/quickfix/quick-fix-graph-parser.ts
+++ b/src/dictionary/parser/quickfix/quick-fix-graph-parser.ts
@@ -1,0 +1,450 @@
+/**
+ * Graph-based QuickFix XML dictionary parser.
+ *
+ * Verbatim port of C# QuickFixXmlFileParser. Uses XDocument tree (from SaxTreeBuilder)
+ * for random-access XML traversal and a Node/Edge/work-queue pattern for forward
+ * reference resolution. Replaces the iterative N-pass SAX-streaming approach.
+ *
+ * Pre-parse validation via DictionaryValidator catches missing fields, duplicates,
+ * and undefined references with "did you mean" suggestions before parsing begins.
+ */
+import { XDocument, XNode } from './x-element'
+import { SaxTreeBuilder } from './sax-tree-builder'
+import { DictionaryValidator } from './dictionary-validator'
+import { FixDefinitions } from '../../definition/fix-definitions'
+import { SimpleFieldDefinition } from '../../definition/simple-field-definition'
+import { ComponentFieldDefinition } from '../../definition/component-field-definition'
+import { GroupFieldDefinition } from '../../definition/group-field-definition'
+import { MessageDefinition } from '../../definition/message-definition'
+import { ContainedFieldSet } from '../../contained/contained-field-set'
+import { ContainedSimpleField } from '../../contained/contained-simple-field'
+import { ContainedComponentField } from '../../contained/contained-component-field'
+import { ContainedGroupField } from '../../contained/contained-group-field'
+import { ContainedSetBuilder } from '../../contained/contained-set-builder'
+import { FixDefinitionSource } from '../../fix-definition-source'
+import { VersionUtil } from '../../version-util'
+import { IndexVisitor } from './index-visitor'
+
+export enum NodeElementType {
+  MessageDefinition = 'MessageDefinition',
+  SimpleFieldDefinition = 'SimpleFieldDefinition',
+  SimpleFieldDeclaration = 'SimpleFieldDeclaration',
+  InlineGroupDefinition = 'InlineGroupDefinition',
+  GroupDefinition = 'GroupDefinition',
+  GroupDeclaration = 'GroupDeclaration',
+  ComponentDefinition = 'ComponentDefinition',
+  ComponentDeclaration = 'ComponentDeclaration'
+}
+
+export interface Edge {
+  readonly head: number
+  readonly tail: number
+}
+
+export class GraphNode {
+  private readonly _edges: Edge[] = []
+
+  constructor (
+    public readonly id: number,
+    public readonly name: string,
+    public readonly type: NodeElementType,
+    public readonly element: XNode
+  ) {}
+
+  get edges (): ReadonlyArray<Edge> {
+    return this._edges
+  }
+
+  makeEdge (tail: number): Edge {
+    const edge: Edge = { head: this.id, tail }
+    this._edges.push(edge)
+    return edge
+  }
+
+  isRequired (): boolean {
+    if (this.name === 'StandardHeader' || this.name === 'StandardTrailer') return true
+    return this.element.attribute('required') === 'Y'
+  }
+
+  toString (): string {
+    return `Node: id=${this.id}, name=${this.name}, type=${this.type}`
+  }
+}
+
+export interface QuickFixGraphParserOptions {
+  validateBeforeParsing?: boolean
+}
+
+export class QuickFixGraphParser {
+  private readonly definitions: FixDefinitions
+  private readonly nodes = new Map<number, GraphNode>()
+  private readonly containedSets = new Map<number, ContainedFieldSet>()
+  private readonly queue: GraphNode[] = []
+  private nextId = 0
+  private header: GraphNode | null = null
+  private trailer: GraphNode | null = null
+
+  public validator: DictionaryValidator | null = null
+  public readonly validateBeforeParsing: boolean
+
+  constructor (definitions: FixDefinitions, options: QuickFixGraphParserOptions = {}) {
+    this.definitions = definitions
+    this.validateBeforeParsing = options.validateBeforeParsing ?? true
+  }
+
+  /**
+   * Parse XML text into the FixDefinitions provided at construction.
+   * Throws DictionaryValidationException if validation is enabled and errors are found.
+   */
+  parseText (xml: string): FixDefinitions {
+    const doc = SaxTreeBuilder.parse(xml)
+    return this.parseDocument(doc)
+  }
+
+  /**
+   * Parse a pre-built XDocument tree.
+   */
+  parseDocument (doc: XDocument): FixDefinitions {
+    if (this.validateBeforeParsing) {
+      this.validator = new DictionaryValidator()
+      this.validator.validate(doc)
+      this.validator.throwIfErrors()
+    }
+
+    this.parseVersion(doc)
+    this.parseFields(doc)
+    this.parseComponents(doc)
+    this.parseHeader(doc)
+    this.parseTrailer(doc)
+    this.parseMessages(doc)
+
+    while (this.queue.length > 0) {
+      const node = this.queue.shift()!
+      this.work(node)
+    }
+
+    /*
+     * At this point all fields on all sets are placed, however the parent (e.g. an
+     * Instrument component) is not aware of the tags contained in nested groups/components
+     * that were resolved AFTER it. The IndexVisitor walks every message and re-indexes
+     * its tree post-order so each set knows all tags below it — essential for the segment
+     * parser to work.
+     */
+    new IndexVisitor().compute(this.definitions)
+
+    return this.definitions
+  }
+
+  // ── Graph construction ──
+
+  private makeNode (name: string, element: XNode, type: NodeElementType): GraphNode {
+    const node = new GraphNode(this.nextId++, name, type, element)
+    this.nodes.set(node.id, node)
+    this.queue.push(node)
+    return node
+  }
+
+  private constructTailNode (name: string, headNode: GraphNode, element: XNode, type: NodeElementType): void {
+    const tailNode = this.makeNode(name, element, type)
+    headNode.makeEdge(tailNode.id)
+    tailNode.makeEdge(headNode.id)
+  }
+
+  // ── Parsing entry points ──
+
+  private parseVersion (doc: XDocument): void {
+    const version = doc.firstDescendant('fix')
+    if (!version) throw new Error('no <fix> root element')
+    const major = parseInt(version.attribute('major') ?? '0', 10)
+    const minor = parseInt(version.attribute('minor') ?? '0', 10)
+    const servicepack = parseInt(version.attribute('servicepack') ?? '0', 10)
+    const description = (major !== 5 || servicepack === 0)
+      ? `FIX.${major}.${minor}`
+      : `FIX.${major}.${minor}SP${servicepack}`
+    const resolved = VersionUtil.resolve(description)
+    // FixDefinitions doesn't have a setVersion — version is set at construction
+    if (resolved !== this.definitions.version) {
+      throw new Error(`version mismatch: dictionary declares ${description} but FixDefinitions was constructed with ${this.definitions.version}`)
+    }
+  }
+
+  private parseFields (doc: XDocument): void {
+    const fieldsNode = doc.firstDescendant('fields')
+    if (!fieldsNode) return
+    for (const fieldElement of fieldsNode.elements('field')) {
+      this.makeNode(QuickFixGraphParser.nameFrom(fieldElement), fieldElement, NodeElementType.SimpleFieldDefinition)
+    }
+  }
+
+  private parseComponents (doc: XDocument): void {
+    const componentsNode = doc.firstDescendant('components')
+    if (!componentsNode) return
+    for (const componentElement of componentsNode.elements('component')) {
+      this.makeNode(QuickFixGraphParser.nameFrom(componentElement), componentElement, NodeElementType.ComponentDefinition)
+    }
+  }
+
+  private parseHeader (doc: XDocument): void {
+    const header = doc.firstDescendant('header')
+    if (!header) throw new Error('no header declared in fix definitions')
+    this.header = this.makeNode('StandardHeader', header, NodeElementType.ComponentDefinition)
+  }
+
+  private parseTrailer (doc: XDocument): void {
+    const trailer = doc.firstDescendant('trailer')
+    if (!trailer) throw new Error('no trailer declared in fix definitions')
+    this.trailer = this.makeNode('StandardTrailer', trailer, NodeElementType.ComponentDefinition)
+  }
+
+  private parseMessages (doc: XDocument): void {
+    const messagesNode = doc.firstDescendant('messages')
+    if (!messagesNode) return
+    for (const messageElement of messagesNode.elements('message')) {
+      const msgType = messageElement.attribute('msgtype')
+      if (!msgType) continue
+      this.makeNode(msgType, messageElement, NodeElementType.MessageDefinition)
+    }
+  }
+
+  // ── Work queue dispatch ──
+
+  private work (node: GraphNode): void {
+    switch (node.type) {
+      case NodeElementType.SimpleFieldDefinition: {
+        const sd = QuickFixGraphParser.getField(node.element)
+        this.definitions.addSimpleFieldDef(sd)
+        break
+      }
+      case NodeElementType.MessageDefinition: {
+        this.messageDefinition(node)
+        break
+      }
+      case NodeElementType.ComponentDefinition: {
+        this.componentDefinition(node)
+        break
+      }
+      case NodeElementType.SimpleFieldDeclaration: {
+        this.simpleFieldDeclaration(node)
+        break
+      }
+      case NodeElementType.InlineGroupDefinition: {
+        this.inlineGroupDefinition(node)
+        break
+      }
+      case NodeElementType.GroupDefinition: {
+        this.groupDefinition(node)
+        break
+      }
+      case NodeElementType.ComponentDeclaration: {
+        this.componentDeclaration(node)
+        break
+      }
+      case NodeElementType.GroupDeclaration: {
+        // QuickFix XML never has standalone group declarations — groups are always inline
+        break
+      }
+    }
+  }
+
+  // ── Definition handlers ──
+
+  private getComponentDefinition (node: GraphNode): ComponentFieldDefinition {
+    let definition = this.definitions.component.get(node.name)
+    if (definition) return definition
+    definition = new ComponentFieldDefinition(node.name, node.name, null, node.name)
+    this.definitions.addComponentFieldDef(definition)
+    return definition
+  }
+
+  private componentDeclaration (node: GraphNode): void {
+    const definition = this.getComponentDefinition(node)
+    const edge = node.edges[0]
+    const parentSet = this.containedSets.get(edge.tail)
+    if (!parentSet) {
+      throw new Error(`edge tail ${edge.tail} has no contained set on which to place declared component '${node.name}'`)
+    }
+    const containedComponent = new ContainedComponentField(definition, parentSet.fields.length, node.isRequired())
+    new ContainedSetBuilder(parentSet).add(containedComponent)
+    this.containedSets.set(edge.head, definition)
+  }
+
+  private messageDefinition (node: GraphNode): void {
+    if (!this.header) throw new Error('header not set')
+    if (!this.trailer) throw new Error('trailer not set')
+
+    const md = QuickFixGraphParser.getMessage(node.element)
+    this.definitions.addMessage(md)
+    this.containedSets.set(node.id, md)
+
+    // wrap the message body in StandardHeader + content + StandardTrailer
+    this.constructTailNode('StandardHeader', node, this.header.element, NodeElementType.ComponentDeclaration)
+    this.expandSet(node)
+    this.constructTailNode('StandardTrailer', node, this.trailer.element, NodeElementType.ComponentDeclaration)
+  }
+
+  private componentDefinition (node: GraphNode): void {
+    const definition = this.getComponentDefinition(node)
+    this.containedSets.set(node.id, definition)
+    this.expandSet(node)
+  }
+
+  private groupDefinition (node: GraphNode): void {
+    const tail = node.edges[0]?.tail
+    if (tail == null) {
+      throw new Error(`node ${node} has no edges to find tail for group definition`)
+    }
+    const definition = this.containedSets.get(tail)
+    if (!definition) {
+      throw new Error(`node ${node} has no contained set for group definition`)
+    }
+    this.containedSets.set(node.edges[0].head, definition)
+    this.expandSet(node)
+  }
+
+  private inlineGroupDefinition (node: GraphNode): void {
+    const edge = node.edges[0]
+    if (!edge) {
+      throw new Error(`node ${node} has no edges to find tail for inline group definition`)
+    }
+    const parentSet = this.containedSets.get(edge.tail)
+    if (!parentSet) {
+      throw new Error(`edge tail ${edge.tail} has no contained set for inline group '${node.name}'`)
+    }
+    const noOFieldDefinition = this.definitions.simple.get(node.name)
+    if (!noOFieldDefinition) {
+      throw new Error(`${node.name} does not exist in simple field definitions to construct inline group`)
+    }
+    const name = node.name
+    const definition = new GroupFieldDefinition(name, name, null, noOFieldDefinition, name)
+    const containedGroup = new ContainedGroupField(definition, parentSet.fields.length, node.isRequired())
+    new ContainedSetBuilder(parentSet).add(containedGroup)
+    this.containedSets.set(edge.head, definition)
+    this.constructTailNode(name, node, node.element, NodeElementType.GroupDefinition)
+  }
+
+  private simpleFieldDeclaration (node: GraphNode): void {
+    const edge = node.edges[0]
+    if (!edge) {
+      throw new Error(`node ${node} has no edges to find tail for simple field declaration`)
+    }
+    const parentSet = this.containedSets.get(edge.tail)
+    if (!parentSet) {
+      throw new Error(`edge tail ${edge.tail} has no contained set for declared field '${node.name}'`)
+    }
+    const sd = this.definitions.simple.get(node.name)
+    if (!sd) {
+      throw new Error(`element ${node} cannot be located as a simple field`)
+    }
+    const containedSimpleField = new ContainedSimpleField(sd, parentSet.fields.length, node.isRequired(), false)
+    new ContainedSetBuilder(parentSet).add(containedSimpleField)
+  }
+
+  // ── Set expansion ──
+
+  /**
+   * Walks the children of a definition node and constructs tail nodes for each
+   * field/group/component reference, queuing them for resolution.
+   */
+  private expandSet (node: GraphNode): void {
+    for (const child of node.element.elements()) {
+      switch (child.name) {
+        case 'field': {
+          this.expandField(node, child)
+          break
+        }
+        case 'group': {
+          this.expandGroup(node, child)
+          break
+        }
+        case 'component': {
+          this.expandComponent(node, child)
+          break
+        }
+      }
+    }
+  }
+
+  private expandField (node: GraphNode, element: XNode): void {
+    this.constructTailNode(QuickFixGraphParser.nameFrom(element), node, element, NodeElementType.SimpleFieldDeclaration)
+  }
+
+  private expandGroup (node: GraphNode, element: XNode): void {
+    this.expandSetChild(node, element, NodeElementType.InlineGroupDefinition, NodeElementType.GroupDeclaration)
+  }
+
+  private expandComponent (node: GraphNode, element: XNode): void {
+    this.expandSetChild(node, element, NodeElementType.ComponentDefinition, NodeElementType.ComponentDeclaration)
+  }
+
+  private expandSetChild (
+    node: GraphNode,
+    element: XNode,
+    defineElement: NodeElementType,
+    declareElement: NodeElementType
+  ): void {
+    const name = QuickFixGraphParser.nameFrom(element)
+    const hasInlinedFields = element.elements().length > 0
+    const elementType = hasInlinedFields ? defineElement : declareElement
+    this.constructTailNode(name, node, element, elementType)
+  }
+
+  // ── Static helpers ──
+
+  /**
+   * Extract a name from an element's attributes, with the same conventions as the C# parser:
+   * strip spaces, prefix with 'F' if the name starts with a digit.
+   */
+  static nameFrom (element: XNode): string {
+    let name = element.attribute('name') ?? ''
+    name = name.replace(/ /g, '')
+    if (name.length > 0 && name[0] >= '0' && name[0] <= '9') {
+      name = `F${name}`
+    }
+    return name
+  }
+
+  static getField (element: XNode): SimpleFieldDefinition {
+    const name = QuickFixGraphParser.nameFrom(element)
+    const numberStr = element.attribute('number')
+    const tag = numberStr != null ? parseInt(numberStr, 10) : -1
+    if (tag < 0) throw new Error(`no tag/number for ${name}`)
+    const type = element.attribute('type') ?? 'STRING'
+
+    const sd = new SimpleFieldDefinition(String(tag), name, name, null, null, type, null)
+    // Add enum values
+    for (const value of element.elements('value')) {
+      const enumKey = value.attribute('enum')
+      const description = value.attribute('description') ?? ''
+      if (enumKey != null) {
+        sd.addEnum(enumKey, description, description)
+      }
+    }
+    return sd
+  }
+
+  static getMessage (element: XNode): MessageDefinition {
+    const name = QuickFixGraphParser.nameFrom(element)
+    const msgCat = element.attribute('msgcat') ?? ''
+    const msgType = element.attribute('msgtype') ?? ''
+    return new MessageDefinition(name, name, msgType, msgCat, name)
+  }
+
+  /**
+   * Convenience: parse XML text into a fresh FixDefinitions.
+   */
+  static parse (xml: string, options: QuickFixGraphParserOptions = {}): FixDefinitions {
+    // Pre-parse the version so we can construct FixDefinitions correctly
+    const doc = SaxTreeBuilder.parse(xml)
+    const fixRoot = doc.firstDescendant('fix')
+    if (!fixRoot) throw new Error('no <fix> root element')
+    const major = parseInt(fixRoot.attribute('major') ?? '0', 10)
+    const minor = parseInt(fixRoot.attribute('minor') ?? '0', 10)
+    const servicepack = parseInt(fixRoot.attribute('servicepack') ?? '0', 10)
+    const description = (major !== 5 || servicepack === 0)
+      ? `FIX.${major}.${minor}`
+      : `FIX.${major}.${minor}SP${servicepack}`
+    const definitions = new FixDefinitions(FixDefinitionSource.QuickFix, VersionUtil.resolve(description))
+    const parser = new QuickFixGraphParser(definitions, options)
+    return parser.parseDocument(doc)
+  }
+}

--- a/src/dictionary/parser/quickfix/x-element.ts
+++ b/src/dictionary/parser/quickfix/x-element.ts
@@ -99,13 +99,17 @@ export class XDocument {
     this.root = new XNode(rootElement)
   }
 
-  /** All descendants of the root with the given tag name. */
+  /** All descendants of the root with the given tag name (including the root itself if it matches). */
   descendants (name: string): XNode[] {
-    return this.root.descendants(name)
+    const result: XNode[] = []
+    if (this.root.name === name) result.push(this.root)
+    result.push(...this.root.descendants(name))
+    return result
   }
 
-  /** First descendant of the root with the given tag name. */
+  /** First descendant of the root with the given tag name (including the root itself if it matches). */
   firstDescendant (name: string): XNode | undefined {
+    if (this.root.name === name) return this.root
     return this.root.firstDescendant(name)
   }
 }

--- a/src/test/dictionary/quick-fix-graph-parser.test.ts
+++ b/src/test/dictionary/quick-fix-graph-parser.test.ts
@@ -1,0 +1,194 @@
+import 'reflect-metadata'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { QuickFixGraphParser } from '../../dictionary/parser/quickfix/quick-fix-graph-parser'
+import { DictionaryValidationException } from '../../dictionary/parser/quickfix/validation-error'
+import { DefinitionFactory } from '../../util/definition-factory'
+import { FixDefinitions } from '../../dictionary/definition'
+import { ContainedFieldType } from '../../dictionary/contained/contained-field-type'
+
+const dataRoot = path.join(__dirname, '../../../data')
+const fixFiles = ['FIX42.xml', 'FIX43.xml', 'FIX44.xml', 'FIX50SP2.xml']
+
+describe('QuickFixGraphParser — basic parsing', () => {
+  test('parses FIX44 minimal structure', () => {
+    const xml = fs.readFileSync(path.join(dataRoot, 'FIX44.xml'), 'utf-8')
+    const defs = QuickFixGraphParser.parse(xml)
+    expect(defs).toBeTruthy()
+    expect(defs.simple.size).toBeGreaterThan(0)
+    expect(defs.message.size).toBeGreaterThan(0)
+    expect(defs.component.size).toBeGreaterThan(0)
+  })
+
+  test('parsed message has StandardHeader and StandardTrailer', () => {
+    const xml = fs.readFileSync(path.join(dataRoot, 'FIX44.xml'), 'utf-8')
+    const defs = QuickFixGraphParser.parse(xml)
+    const logon = defs.message.get('Logon')
+    expect(logon).toBeTruthy()
+    expect(logon!.components.has('StandardHeader')).toBe(true)
+    expect(logon!.components.has('StandardTrailer')).toBe(true)
+  })
+
+  test('field definitions have tags and types', () => {
+    const xml = fs.readFileSync(path.join(dataRoot, 'FIX44.xml'), 'utf-8')
+    const defs = QuickFixGraphParser.parse(xml)
+    const beginString = defs.simple.get('BeginString')
+    expect(beginString).toBeTruthy()
+    expect(beginString!.tag).toBe(8)
+  })
+
+  test('throws on invalid xml when validation enabled', () => {
+    const badXml = '<fix><fields><field number="1" /></fields></fix>'
+    expect(() => QuickFixGraphParser.parse(badXml)).toThrow(DictionaryValidationException)
+  })
+
+  test('skips validation when disabled', () => {
+    const xml = `<fix major="4" minor="4">
+      <header><field name="BeginString" required="Y" /></header>
+      <trailer><field name="CheckSum" required="Y" /></trailer>
+      <fields>
+        <field number="8" name="BeginString" type="STRING" />
+        <field number="10" name="CheckSum" type="STRING" />
+      </fields>
+      <messages />
+    </fix>`
+    expect(() => QuickFixGraphParser.parse(xml, { validateBeforeParsing: false })).not.toThrow()
+  })
+})
+
+describe('QuickFixGraphParser — comparison with existing parser', () => {
+  const factory = new DefinitionFactory()
+  const cache = new Map<string, { graph: FixDefinitions, legacy: FixDefinitions }>()
+
+  async function loadBoth (file: string): Promise<{ graph: FixDefinitions, legacy: FixDefinitions }> {
+    if (cache.has(file)) return cache.get(file)!
+    const filePath = path.join(dataRoot, file)
+    const xml = fs.readFileSync(filePath, 'utf-8')
+    const graph = QuickFixGraphParser.parse(xml, { validateBeforeParsing: false })
+    const legacy = await factory.getDefinitions(filePath)
+    const result = { graph, legacy }
+    cache.set(file, result)
+    return result
+  }
+
+  fixFiles.forEach(file => {
+    const filePath = path.join(dataRoot, file)
+    if (!fs.existsSync(filePath)) return
+
+    describe(file, () => {
+      test('same number of simple field definitions (by tag)', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        // simple map has many aliases — compare unique tag count
+        const graphTags = new Set(Array.from(graph.simple.values()).map(s => s.tag))
+        const legacyTags = new Set(Array.from(legacy.simple.values()).map(s => s.tag))
+        expect(graphTags.size).toBe(legacyTags.size)
+      })
+
+      test('all legacy field tags exist in graph', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        const graphTags = new Set(Array.from(graph.simple.values()).map(s => s.tag))
+        for (const sd of legacy.simple.values()) {
+          expect(graphTags.has(sd.tag)).toBe(true)
+        }
+      })
+
+      test('same number of messages', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        // Messages map by both name and msgType — count unique
+        const graphMsgs = new Set(Array.from(graph.message.values()))
+        const legacyMsgs = new Set(Array.from(legacy.message.values()))
+        expect(graphMsgs.size).toBe(legacyMsgs.size)
+      })
+
+      test('all legacy messages exist in graph by msgType', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        const seen = new Set<string>()
+        for (const md of legacy.message.values()) {
+          if (seen.has(md.msgType)) continue
+          seen.add(md.msgType)
+          const graphMd = graph.message.get(md.msgType)
+          expect(graphMd).toBeTruthy()
+          expect(graphMd!.name).toBe(md.name)
+        }
+      })
+
+      test('messages have same field counts (top level)', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        const seen = new Set<string>()
+        for (const md of legacy.message.values()) {
+          if (seen.has(md.msgType)) continue
+          seen.add(md.msgType)
+          const graphMd = graph.message.get(md.msgType)!
+          // Both should include StandardHeader + body + StandardTrailer
+          expect(graphMd.fields.length).toBe(md.fields.length)
+        }
+      })
+
+      test('graph parser includes all legacy flattened tags (may have more)', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        const seen = new Set<string>()
+        for (const md of legacy.message.values()) {
+          if (seen.has(md.msgType)) continue
+          seen.add(md.msgType)
+          const graphMd = graph.message.get(md.msgType)!
+          const graphTags = new Set(Object.keys(graphMd.containedTag).map(Number))
+          const legacyTags = new Set(Object.keys(md.containedTag).map(Number))
+          // Graph parser correctly resolves deeply nested forward references
+          // that the legacy 5-pass parser truncates — so graph may be superset.
+          for (const t of legacyTags) {
+            expect(graphTags.has(t)).toBe(true)
+          }
+          expect(graphTags.size).toBeGreaterThanOrEqual(legacyTags.size)
+        }
+      })
+
+      test('components have same counts', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        // Component map may include StandardHeader/StandardTrailer too
+        expect(graph.component.size).toBe(legacy.component.size)
+      })
+
+      test('components have same field counts', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        for (const [name, legacyComp] of legacy.component.entries()) {
+          const graphComp = graph.component.get(name)
+          expect(graphComp).toBeTruthy()
+          expect(graphComp!.fields.length).toBe(legacyComp.fields.length)
+        }
+      })
+
+      test('graph parser includes all legacy groups (may have more)', async () => {
+        const { graph, legacy } = await loadBoth(file)
+        const seen = new Set<string>()
+        for (const md of legacy.message.values()) {
+          if (seen.has(md.msgType)) continue
+          seen.add(md.msgType)
+          const graphMd = graph.message.get(md.msgType)!
+
+          const legacyGroups = collectGroupNames(md)
+          const graphGroups = collectGroupNames(graphMd)
+          // Graph parser may resolve more deeply nested groups than legacy.
+          for (const g of legacyGroups) {
+            expect(graphGroups.has(g)).toBe(true)
+          }
+          expect(graphGroups.size).toBeGreaterThanOrEqual(legacyGroups.size)
+        }
+      })
+    })
+  })
+})
+
+function collectGroupNames (set: any, acc: Set<string> = new Set(), visited: Set<any> = new Set()): Set<string> {
+  if (visited.has(set)) return acc
+  visited.add(set)
+  for (const f of set.fields) {
+    if (f.type === ContainedFieldType.Group) {
+      acc.add(f.name)
+      if (f.definition) collectGroupNames(f.definition, acc, visited)
+    } else if (f.type === ContainedFieldType.Component) {
+      if (f.definition) collectGroupNames(f.definition, acc, visited)
+    }
+  }
+  return acc
+}

--- a/src/test/dictionary/quick-fix-graph-parser.test.ts
+++ b/src/test/dictionary/quick-fix-graph-parser.test.ts
@@ -77,6 +77,13 @@ describe('QuickFixGraphParser — comparison with existing parser', () => {
     if (!fs.existsSync(filePath)) return
 
     describe(file, () => {
+      // Pre-load both parsers in beforeAll so the slow legacy parse cost
+      // (especially FIX50SP2) doesn't get absorbed by whichever test runs
+      // first and exceed the default 5s timeout.
+      beforeAll(async () => {
+        await loadBoth(file)
+      }, 60000)
+
       test('same number of simple field definitions (by tag)', async () => {
         const { graph, legacy } = await loadBoth(file)
         // simple map has many aliases — compare unique tag count

--- a/src/test/dictionary/trim-round-trip.test.ts
+++ b/src/test/dictionary/trim-round-trip.test.ts
@@ -1,0 +1,171 @@
+import 'reflect-metadata'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { QuickFixGraphParser } from '../../dictionary/parser/quickfix/quick-fix-graph-parser'
+import { QuickFixXmlFileBuilder } from '../../dictionary/parser/quickfix/quick-fix-xml-file-builder'
+import { FixDefinitions } from '../../dictionary/definition'
+
+const dataRoot = path.join(__dirname, '../../../data')
+
+/**
+ * Round-trip: parse a FIX dictionary with the graph parser (complete picture),
+ * trim it down to a subset of message types, then re-parse the trimmed XML
+ * with the strict graph parser. The validator will catch any undefined
+ * field/component references — exactly the kind of bug where deeply nested
+ * fields are dropped during trim.
+ */
+async function trimAndReparse (
+  filePath: string,
+  msgTypes: string[]
+): Promise<{ original: FixDefinitions, trimmed: FixDefinitions, xml: string }> {
+  const xml = fs.readFileSync(filePath, 'utf-8')
+  const original = QuickFixGraphParser.parse(xml, { validateBeforeParsing: false })
+  const builder = new QuickFixXmlFileBuilder(original)
+  builder.write(msgTypes)
+  const trimmedXml = builder.elasticBuffer.toString()
+  // Parse with strict validation enabled — will throw if anything is missing
+  const trimmed = QuickFixGraphParser.parse(trimmedXml, { validateBeforeParsing: true })
+  return { original, trimmed, xml: trimmedXml }
+}
+
+function compareMessageFully (original: FixDefinitions, trimmed: FixDefinitions, msgType: string): void {
+  const o = original.message.get(msgType)
+  const t = trimmed.message.get(msgType)
+  expect(t).toBeTruthy()
+  if (!o || !t) return
+
+  // Top-level field count must match
+  expect(t.fields.length).toBe(o.fields.length)
+
+  // Flattened tag set must match (catches deeply-nested missing fields)
+  const oTags = new Set(Object.keys(o.containedTag).map(Number))
+  const tTags = new Set(Object.keys(t.containedTag).map(Number))
+  const missing = [...oTags].filter(tag => !tTags.has(tag))
+  if (missing.length > 0) {
+    const lookup = (tag: number) => {
+      for (const sd of original.simple.values()) {
+        if (sd.tag === tag) return sd.name
+      }
+      return `tag${tag}`
+    }
+    throw new Error(`${msgType}: ${missing.length} tags lost during trim: ${missing.slice(0, 10).map(lookup).join(', ')}${missing.length > 10 ? '...' : ''}`)
+  }
+  expect(tTags.size).toBe(oTags.size)
+}
+
+/**
+ * Walk the message tree and check that every nested component/group exists
+ * in the trimmed definitions with matching field counts.
+ */
+function compareNestedSets (original: FixDefinitions, trimmed: FixDefinitions, msgType: string): void {
+  const o = original.message.get(msgType)
+  const t = trimmed.message.get(msgType)
+  if (!o || !t) return
+
+  const visited = new Set<string>()
+
+  function walk (oSet: any, tSet: any, path: string): void {
+    if (visited.has(path)) return
+    visited.add(path)
+
+    // Direct field count
+    if (oSet.fields.length !== tSet.fields.length) {
+      throw new Error(`${msgType} ${path}: expected ${oSet.fields.length} fields, got ${tSet.fields.length}`)
+    }
+
+    // Component children
+    for (const [name, oComp] of oSet.components.entries()) {
+      const tComp = tSet.components.get(name)
+      if (!tComp) {
+        throw new Error(`${msgType} ${path}: missing component '${name}' in trimmed`)
+      }
+      walk(oComp, tComp, `${path}.${name}`)
+    }
+
+    // Group children
+    for (const [name, oGrp] of oSet.groups.entries()) {
+      const tGrp = tSet.groups.get(name)
+      if (!tGrp) {
+        throw new Error(`${msgType} ${path}: missing group '${name}' in trimmed`)
+      }
+      walk(oGrp, tGrp, `${path}.${name}`)
+    }
+  }
+
+  walk(o, t, msgType)
+}
+
+describe('trim round-trip — FIX44', () => {
+  const filePath = path.join(dataRoot, 'FIX44.xml')
+
+  test('Heartbeat (0)', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['0'])
+    compareMessageFully(original, trimmed, '0')
+  })
+
+  test('NewOrderSingle (D)', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['D'])
+    compareMessageFully(original, trimmed, 'D')
+  })
+
+  test('ExecutionReport (8)', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['8'])
+    compareMessageFully(original, trimmed, '8')
+  })
+
+  test('multi-message trim', async () => {
+    const msgTypes = ['0', '1', '2', '3', '4', '5', 'D', '8']
+    const { original, trimmed } = await trimAndReparse(filePath, msgTypes)
+    for (const mt of msgTypes) {
+      compareMessageFully(original, trimmed, mt)
+    }
+  })
+})
+
+describe('trim round-trip — FIX50SP2', () => {
+  const filePath = path.join(dataRoot, 'FIX50SP2.xml')
+
+  test('Heartbeat (0)', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['0'])
+    compareMessageFully(original, trimmed, '0')
+  })
+
+  test('TradeCaptureReport (AE) — deeply nested groups', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['AE'])
+    compareMessageFully(original, trimmed, 'AE')
+    compareNestedSets(original, trimmed, 'AE')
+  })
+
+  test('NewOrderSingle (D)', async () => {
+    const { original, trimmed } = await trimAndReparse(filePath, ['D'])
+    compareMessageFully(original, trimmed, 'D')
+  })
+
+  test('many messages', async () => {
+    const msgTypes = ['0', '1', '2', '3', '4', '5', 'AE', 'D', '8']
+    const { original, trimmed } = await trimAndReparse(filePath, msgTypes)
+    for (const mt of msgTypes) {
+      compareMessageFully(original, trimmed, mt)
+    }
+  })
+
+  test('all messages — full round trip with deep comparison', async () => {
+    // Parse the full dictionary, trim ALL messages, reparse, compare every message
+    // including deeply-nested set structures. This is the strongest check possible.
+    const xml = fs.readFileSync(filePath, 'utf-8')
+    const original = QuickFixGraphParser.parse(xml, { validateBeforeParsing: false })
+    const allMsgTypes = new Set<string>()
+    for (const md of original.message.values()) {
+      allMsgTypes.add(md.msgType)
+    }
+    const builder = new QuickFixXmlFileBuilder(original)
+    builder.write([...allMsgTypes])
+    const trimmedXml = builder.elasticBuffer.toString()
+    const trimmed = QuickFixGraphParser.parse(trimmedXml, { validateBeforeParsing: true })
+    for (const mt of allMsgTypes) {
+      compareMessageFully(original, trimmed, mt)
+      compareNestedSets(original, trimmed, mt)
+    }
+  }, 60000)
+})


### PR DESCRIPTION
## Summary

After investigation, the trim "bug" we expected to backport from C# was actually **introduced during the C# port itself** (cspurefix commit \`2ee4620c\`).

**The TS \`QuickFixXmlFileBuilder\` is correct** — it uses an iterative \`while (components.length > 0) { components.pop() }\` discovery loop where newly-pushed components are processed in subsequent iterations.

**The C# port lost the iterative loop**, replacing it with a \`foreach\` over a snapshot of \`_seenComponents.Values.ToList()\`. This silently dropped any components discovered while iterating. The C# fix added \`ProcessComponentFields\` for eager recursive collection — that fix is patching the regression, not a bug shared with TS.

## Changes
- No code changes to \`quick-fix-xml-file-builder.ts\` — confirmed correct
- Added \`src/test/dictionary/trim-round-trip.test.ts\` with 9 tests:
  - Trim → reparse with strict graph parser validation
  - Flattened tag set comparison at message level
  - Deep nested-set comparison (every component/group at every depth)
  - Worst case: trim ALL 116 FIX50SP2 messages with full deep comparison
- Updated BACKPORT_PLAN.md to document the finding

## Test plan
- [x] All 9 round-trip tests pass on FIX44 and FIX50SP2
- [x] FIX50SP2 TradeCaptureReport (AE) — deeply nested groups — round-trips perfectly
- [x] All 533 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)