### PR TITLE
feat: switch default QuickFix parser to graph-based implementation (PR 6E)

### DIFF
--- a/BACKPORT_PLAN.md
+++ b/BACKPORT_PLAN.md
@@ -309,13 +309,20 @@ Includes `IndexVisitor` post-processor (originally PR 6D, merged into 6C because
 
 #### PR 6E: Switch default parser (HIGH risk)
 
-| File | Action |
-|------|--------|
-| `src/dictionary/definition-factory.ts` (or equivalent) | Default to graph-based parser for QuickFix XML |
-| `src/dictionary/parser/quickfix/quick-fix-xml-file-parser.ts` | Mark as deprecated / legacy fallback |
-| Remove: `parse-progress.ts`, `parse-state.ts` | No longer needed (old multi-pass state machine) |
+### Status: **DONE**
 
-Only after extensive testing across all FIX versions and trim round-trips.
+Added `QuickFixGraphFileParser` adapter that extends `FixParser` and matches the legacy parser's `(MakeDuplex, GetJsFixLogger)` constructor signature. `DefinitionFactory.getParser()` now instantiates the graph parser for QuickFix XML — all dictionary loading goes through the graph parser by default.
+
+The legacy `QuickFixXmlFileParser` remains exported for backward compatibility (anyone importing it directly still gets the old behaviour), but no production code in the project uses it.
+
+**Test fallout fixed:**
+- `src/test/env/data/fix5-mod.xml` had a redundant 215-line "admin fields" section that duplicated 62 fields already present in the canonical fields section. Plus the `HopGrp` and `MsgTypeGrp` components were defined twice. The legacy parser silently swallowed both classes of duplicate; the graph parser's validator correctly flags them as errors. Removed the redundant admin section (kept the unique `OTP` custom tag) and the duplicate component definitions.
+- `src/test/ascii/qf-50sp2-dict.test.ts` had two assertions where `Instrument` and `TrdCapRptSideGrp` were expected as `required=false` for TradeCaptureReport. The dictionary clearly says `required='Y'` for both. The legacy parser was producing `required=false` (a real bug); the graph parser correctly returns `true`. Updated the assertions.
+- Updated `getTrimDefinitions` in the same file to use `QuickFixGraphFileParser` instead of the legacy parser for consistency.
+
+All 533 tests pass with the graph parser as the default.
+
+Note: `parse-progress.ts`, `parse-state.ts`, and the legacy parser itself are NOT yet deleted — that's deferred to a follow-up cleanup PR after a release cycle to give downstream consumers time to migrate.
 
 #### PR 6F: Fix Trim function (medium risk)
 
@@ -353,7 +360,7 @@ PR 6F (Fix Trim) ──── after 6C is stable
 | 6B | None | New files only, validation — **DONE** |
 | 6C | Medium | Graph parser + IndexVisitor — sits alongside legacy parser — **DONE** |
 | 6D | (merged into 6C) | IndexVisitor was needed for 6C to work correctly |
-| 6E | HIGH | Switches default parser — must pass all tests across all FIX versions |
+| 6E | HIGH | Switches default parser — exposed 2 legacy parser bugs (now fixed) — **DONE** |
 | 6F | None | TS trim already correct — round-trip tests added — **DONE** |
 
 ### Test Strategy

--- a/src/dictionary/parser/quickfix/index.ts
+++ b/src/dictionary/parser/quickfix/index.ts
@@ -1,5 +1,6 @@
 export * from './quick-fix-xml-file-parser'
 export * from './quick-fix-graph-parser'
+export * from './quick-fix-graph-file-parser'
 export * from './x-element'
 export * from './sax-tree-builder'
 export * from './dictionary-validator'

--- a/src/dictionary/parser/quickfix/quick-fix-graph-file-parser.ts
+++ b/src/dictionary/parser/quickfix/quick-fix-graph-file-parser.ts
@@ -1,0 +1,63 @@
+/**
+ * Drop-in replacement for QuickFixXmlFileParser that uses the graph-based
+ * parser internally. Maintains the same constructor signature so it can be
+ * swapped in the DefinitionFactory without changes to call sites.
+ */
+import { FixParser } from '../../fix-parser'
+import { FixDefinitions } from '../../definition/fix-definitions'
+import { GetJsFixLogger } from '../../../config'
+import { MakeDuplex } from '../../../transport'
+import { SaxTreeBuilder } from './sax-tree-builder'
+import { QuickFixGraphParser, QuickFixGraphParserOptions } from './quick-fix-graph-parser'
+import { FixDefinitionSource } from '../../fix-definition-source'
+import { VersionUtil } from '../../version-util'
+
+export class QuickFixGraphFileParser extends FixParser {
+  constructor (
+    public readonly make: MakeDuplex,
+    public readonly getLogger: GetJsFixLogger,
+    public readonly options: QuickFixGraphParserOptions = {}
+  ) {
+    super()
+  }
+
+  public async parse (): Promise<FixDefinitions> {
+    const xml = await this.readAll()
+    const doc = SaxTreeBuilder.parse(xml)
+
+    const fixRoot = doc.firstDescendant('fix')
+    if (!fixRoot) throw new Error('no <fix> root element')
+    const major = parseInt(fixRoot.attribute('major') ?? '0', 10)
+    const minor = parseInt(fixRoot.attribute('minor') ?? '0', 10)
+    const servicepack = parseInt(fixRoot.attribute('servicepack') ?? '0', 10)
+    const description = (major !== 5 || servicepack === 0)
+      ? `FIX.${major}.${minor}`
+      : `FIX.${major}.${minor}SP${servicepack}`
+
+    const definitions = new FixDefinitions(FixDefinitionSource.QuickFix, VersionUtil.resolve(description))
+    const parser = new QuickFixGraphParser(definitions, this.options)
+    return parser.parseDocument(doc)
+  }
+
+  /**
+   * Read the entire duplex stream into a UTF-8 string. The graph parser
+   * needs the full document in memory because it walks the XDocument tree
+   * with random access — unlike the legacy SAX-streaming parser.
+   */
+  private async readAll (): Promise<string> {
+    const duplex = this.make()
+    const readable = duplex.readable
+    return await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = []
+      readable.on('data', (chunk: Buffer | string) => {
+        chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+      })
+      readable.on('end', () => {
+        resolve(Buffer.concat(chunks).toString('utf-8'))
+      })
+      readable.on('error', (err: Error) => {
+        reject(err)
+      })
+    })
+  }
+}

--- a/src/test/ascii/qf-50sp2-dict.test.ts
+++ b/src/test/ascii/qf-50sp2-dict.test.ts
@@ -5,7 +5,7 @@ import { DefinitionFactory } from '../../util'
 import { SetConstraintHelper } from '../env/set-constraint-helper'
 import { QuickFixXmlFileBuilder } from '../../dictionary/parser/quickfix/quick-fix-xml-file-builder'
 import { FieldEnum, FixVersion } from '../../dictionary'
-import { QuickFixXmlFileParser } from '../../dictionary/parser'
+import { QuickFixGraphFileParser } from '../../dictionary/parser'
 import { StringDuplex } from '../../transport'
 import { EmptyLogger } from '../../config'
 
@@ -82,7 +82,7 @@ function checkTradeCapture (tc: (MessageDefinition | undefined)): void {
   setHelper.isSimple(tc, index++, 'MarketSegmentID', false)
   setHelper.isSimple(tc, index++, 'MarketID', false)
   setHelper.isSimple(tc, index++, 'TaxonomyType', false)
-  setHelper.isComponent(tc, index++, 'Instrument', false)
+  setHelper.isComponent(tc, index++, 'Instrument', true)
   setHelper.isComponent(tc, index++, 'InstrumentExtension', false)
   setHelper.isComponent(tc, index++, 'FinancingDetails', false)
   setHelper.isComponent(tc, index++, 'PaymentGrp', false)
@@ -147,7 +147,7 @@ function checkTradeCapture (tc: (MessageDefinition | undefined)): void {
   setHelper.isSimple(tc, index++, 'ExecMethod', false)
   setHelper.isSimple(tc, index++, 'MatchType', false)
   setHelper.isComponent(tc, index++, 'TradeQtyGrp', false)
-  setHelper.isComponent(tc, index++, 'TrdCapRptSideGrp', false)
+  setHelper.isComponent(tc, index++, 'TrdCapRptSideGrp', true)
   setHelper.isSimple(tc, index++, 'Volatility', false)
   setHelper.isSimple(tc, index++, 'TimeToExpiration', false)
   setHelper.isSimple(tc, index++, 'DividendYield', false)
@@ -223,7 +223,7 @@ async function getTrimDefinitions (types: string[]): Promise<FixDefinitions> {
   const builder = new QuickFixXmlFileBuilder(definitions)
   builder.write(types)
   const d = builder.elasticBuffer.toString()
-  const parser = new QuickFixXmlFileParser(() => new StringDuplex(d), () => new EmptyLogger())
+  const parser = new QuickFixGraphFileParser(() => new StringDuplex(d), () => new EmptyLogger())
   return await parser.parse()
 }
 

--- a/src/test/env/data/fix5-mod.xml
+++ b/src/test/env/data/fix5-mod.xml
@@ -4483,13 +4483,6 @@
                 <field name="NestedPartySubIDType" required="N"/>
             </group>
         </component>
-        <component name="HopGrp">
-            <group name="NoHops" required="N">
-                <field name="HopCompID" required="N"/>
-                <field name="HopSendingTime" required="N"/>
-                <field name="HopRefID" required="N"/>
-            </group>
-        </component>
         <component name="NstdPtys2SubGrp">
             <group name="NoNested2PartySubIDs" required="N">
                 <field name="Nested2PartySubID" required="N"/>
@@ -4718,14 +4711,6 @@
                 <field name="EncodedText" required="N"/>
             </group>
         </component>
-        <component name="MsgTypeGrp">
-            <group name="NoMsgTypes" required="N">
-                <field name="RefMsgType" required="N"/>
-                <field name="MsgDirection" required="N"/>
-                <field name="RefApplVerID" required="N"/>
-                <field name="RefCstmApplVerID" required="N"/>
-            </group>
-        </component>
         <component name="RelatedAccount">
             <group name="NoRelatedAcc" required="N">
                 <field name="Account" required="N" />
@@ -4746,221 +4731,6 @@
         </component>
     </components>
     <fields>
-        <field name="BeginSeqNo" number="7" type="SEQNUM"/>
-        <field name="BeginString" number="8" type="STRING"/>
-        <field name="BodyLength" number="9" type="LENGTH"/>
-        <field name="CheckSum" number="10" type="STRING"/>
-        <field name="EndSeqNo" number="16" type="SEQNUM"/>
-        <field name="MsgSeqNum" number="34" type="SEQNUM"/>
-        <field number="35" name="MsgType" type="STRING">
-            <value enum="0" description="HEARTBEAT"/>
-            <value enum="1" description="TEST_REQUEST"/>
-            <value enum="2" description="RESEND_REQUEST"/>
-            <value enum="3" description="REJECT"/>
-            <value enum="4" description="SEQUENCE_RESET"/>
-            <value enum="5" description="LOGOUT"/>
-            <value enum="6" description="INDICATION_OF_INTEREST"/>
-            <value enum="7" description="ADVERTISEMENT"/>
-            <value enum="8" description="EXECUTION_REPORT"/>
-            <value enum="9" description="ORDER_CANCEL_REJECT"/>
-            <value enum="A" description="LOGON"/>
-            <value enum="B" description="NEWS"/>
-            <value enum="C" description="EMAIL"/>
-            <value enum="D" description="ORDER_SINGLE"/>
-            <value enum="E" description="ORDER_LIST"/>
-            <value enum="F" description="ORDER_CANCEL_REQUEST"/>
-            <value enum="G" description="ORDER_CANCEL_REPLACE_REQUEST"/>
-            <value enum="H" description="ORDER_STATUS_REQUEST"/>
-            <value enum="J" description="ALLOCATION_INSTRUCTION"/>
-            <value enum="K" description="LIST_CANCEL_REQUEST"/>
-            <value enum="L" description="LIST_EXECUTE"/>
-            <value enum="M" description="LIST_STATUS_REQUEST"/>
-            <value enum="N" description="LIST_STATUS"/>
-            <value enum="P" description="ALLOCATION_INSTRUCTION_ACK"/>
-            <value enum="Q" description="DONT_KNOW_TRADE"/>
-            <value enum="R" description="QUOTE_REQUEST"/>
-            <value enum="S" description="QUOTE"/>
-            <value enum="T" description="SETTLEMENT_INSTRUCTIONS"/>
-            <value enum="V" description="MARKET_DATA_REQUEST"/>
-            <value enum="W" description="MARKET_DATA_SNAPSHOT_FULL_REFRESH"/>
-            <value enum="X" description="MARKET_DATA_INCREMENTAL_REFRESH"/>
-            <value enum="Y" description="MARKET_DATA_REQUEST_REJECT"/>
-            <value enum="Z" description="QUOTE_CANCEL"/>
-            <value enum="a" description="QUOTE_STATUS_REQUEST"/>
-            <value enum="b" description="MASS_QUOTE_ACKNOWLEDGEMENT"/>
-            <value enum="c" description="SECURITY_DEFINITION_REQUEST"/>
-            <value enum="d" description="SECURITY_DEFINITION"/>
-            <value enum="e" description="SECURITY_STATUS_REQUEST"/>
-            <value enum="f" description="SECURITY_STATUS"/>
-            <value enum="g" description="TRADING_SESSION_STATUS_REQUEST"/>
-            <value enum="h" description="TRADING_SESSION_STATUS"/>
-            <value enum="i" description="MASS_QUOTE"/>
-            <value enum="j" description="BUSINESS_MESSAGE_REJECT"/>
-            <value enum="k" description="BID_REQUEST"/>
-            <value enum="l" description="BID_RESPONSE"/>
-            <value enum="m" description="LIST_STRIKE_PRICE"/>
-            <value enum="n" description="XML_MESSAGE"/>
-            <value enum="o" description="REGISTRATION_INSTRUCTIONS"/>
-            <value enum="p" description="REGISTRATION_INSTRUCTIONS_RESPONSE"/>
-            <value enum="q" description="ORDER_MASS_CANCEL_REQUEST"/>
-            <value enum="r" description="ORDER_MASS_CANCEL_REPORT"/>
-            <value enum="s" description="NEW_ORDER_CROSS"/>
-            <value enum="t" description="CROSS_ORDER_CANCEL_REPLACE_REQUEST"/>
-            <value enum="u" description="CROSS_ORDER_CANCEL_REQUEST"/>
-            <value enum="v" description="SECURITY_TYPE_REQUEST"/>
-            <value enum="w" description="SECURITY_TYPES"/>
-            <value enum="x" description="SECURITY_LIST_REQUEST"/>
-            <value enum="y" description="SECURITY_LIST"/>
-            <value enum="z" description="DERIVATIVE_SECURITY_LIST_REQUEST"/>
-            <value enum="AA" description="DERIVATIVE_SECURITY_LIST"/>
-            <value enum="AB" description="NEW_ORDER_MULTILEG"/>
-            <value enum="AC" description="MULTILEG_ORDER_CANCEL_REPLACE"/>
-            <value enum="AD" description="TRADE_CAPTURE_REPORT_REQUEST"/>
-            <value enum="AE" description="TRADE_CAPTURE_REPORT"/>
-            <value enum="AF" description="ORDER_MASS_STATUS_REQUEST"/>
-            <value enum="AG" description="QUOTE_REQUEST_REJECT"/>
-            <value enum="AH" description="RFQ_REQUEST"/>
-            <value enum="AI" description="QUOTE_STATUS_REPORT"/>
-            <value enum="AJ" description="QUOTE_RESPONSE"/>
-            <value enum="AK" description="CONFIRMATION"/>
-            <value enum="AL" description="POSITION_MAINTENANCE_REQUEST"/>
-            <value enum="AM" description="POSITION_MAINTENANCE_REPORT"/>
-            <value enum="AN" description="REQUEST_FOR_POSITIONS"/>
-            <value enum="AO" description="REQUEST_FOR_POSITIONS_ACK"/>
-            <value enum="AP" description="POSITION_REPORT"/>
-            <value enum="AQ" description="TRADE_CAPTURE_REPORT_REQUEST_ACK"/>
-            <value enum="AR" description="TRADE_CAPTURE_REPORT_ACK"/>
-            <value enum="AS" description="ALLOCATION_REPORT"/>
-            <value enum="AT" description="ALLOCATION_REPORT_ACK"/>
-            <value enum="AU" description="CONFIRMATION_ACK"/>
-            <value enum="AV" description="SETTLEMENT_INSTRUCTION_REQUEST"/>
-            <value enum="AW" description="ASSIGNMENT_REPORT"/>
-            <value enum="AX" description="COLLATERAL_REQUEST"/>
-            <value enum="AY" description="COLLATERAL_ASSIGNMENT"/>
-            <value enum="AZ" description="COLLATERAL_RESPONSE"/>
-            <value enum="BA" description="COLLATERAL_REPORT"/>
-            <value enum="BB" description="COLLATERAL_INQUIRY"/>
-            <value enum="BC" description="NETWORK_STATUS_REQUEST"/>
-            <value enum="BD" description="NETWORK_STATUS_RESPONSE"/>
-            <value enum="BE" description="USER_REQUEST"/>
-            <value enum="BF" description="USER_RESPONSE"/>
-            <value enum="BG" description="COLLATERAL_INQUIRY_ACK"/>
-            <value enum="BH" description="CONFIRMATION_REQUEST"/>
-            <value enum="BI" description="TRADING_SESSION_LIST_REQUEST"/>
-            <value enum="BJ" description="TRADING_SESSION_LIST"/>
-            <value enum="BK" description="SECURITY_LIST_UPDATE_REPORT"/>
-            <value enum="BL" description="ADJUSTED_POSITION_REPORT"/>
-            <value enum="BM" description="ALLOCATION_INSTRUCTION_ALERT"/>
-            <value enum="BN" description="EXECUTION_ACKNOWLEDGEMENT"/>
-            <value enum="BO" description="CONTRARY_INTENTION_REPORT"/>
-            <value enum="BP" description="SECURITY_DEFINITION_UPDATE_REPORT"/>
-            <value enum="UALR" description="ACCOUNT_LIST_REQUEST"/>
-            <value enum="UALT" description="ACCOUNT_LIST"/>
-            <value enum="UALI" description="ACCOUNT_LIST_INCREMENTAL"/>
-        </field>
-        <field name="NewSeqNo" number="36" type="SEQNUM"/>
-        <field name="PossDupFlag" number="43" type="BOOLEAN"/>
-        <field name="RefSeqNum" number="45" type="SEQNUM"/>
-        <field name="SenderCompID" number="49" type="STRING"/>
-        <field name="SenderSubID" number="50" type="STRING"/>
-        <field name="SendingTime" number="52" type="UTCTIMESTAMP"/>
-        <field name="TargetCompID" number="56" type="STRING"/>
-        <field name="TargetSubID" number="57" type="STRING"/>
-        <field name="Text" number="58" type="STRING"/>
-        <field name="Signature" number="89" type="DATA"/>
-        <field name="SecureDataLen" number="90" type="LENGTH"/>
-        <field name="SecureData" number="91" type="DATA"/>
-        <field name="SignatureLength" number="93" type="LENGTH"/>
-        <field name="RawDataLength" number="95" type="LENGTH"/>
-        <field name="RawData" number="96" type="DATA"/>
-        <field name="PossResend" number="97" type="BOOLEAN"/>
-        <field name="EncryptMethod" number="98" type="INT">
-            <value description="NONE_OTHER" enum="0"/>
-            <value description="PKCS" enum="1"/>
-            <value description="DES" enum="2"/>
-            <value description="PKCS_DES" enum="3"/>
-            <value description="PGP_DES" enum="4"/>
-            <value description="PGP_DES_MD5" enum="5"/>
-            <value description="PEM_DES_MD5" enum="6"/>
-        </field>
-        <field name="HeartBtInt" number="108" type="INT"/>
-        <field name="TestReqID" number="112" type="STRING"/>
-        <field name="OnBehalfOfCompID" number="115" type="STRING"/>
-        <field name="OnBehalfOfSubID" number="116" type="STRING"/>
-        <field name="OrigSendingTime" number="122" type="UTCTIMESTAMP"/>
-        <field name="GapFillFlag" number="123" type="BOOLEAN"/>
-        <field name="DeliverToCompID" number="128" type="STRING"/>
-        <field name="DeliverToSubID" number="129" type="STRING"/>
-        <field name="ResetSeqNumFlag" number="141" type="BOOLEAN"/>
-        <field name="SenderLocationID" number="142" type="STRING"/>
-        <field name="TargetLocationID" number="143" type="STRING"/>
-        <field name="OnBehalfOfLocationID" number="144" type="STRING"/>
-        <field name="DeliverToLocationID" number="145" type="STRING"/>
-        <field name="XmlDataLen" number="212" type="LENGTH"/>
-        <field name="XmlData" number="213" type="DATA"/>
-        <field number="347" name="MessageEncoding" type="STRING">
-            <value enum="ISO-2022-JP" description="ISO_2022_JP"/>
-            <value enum="EUC-JP" description="EUC_JP"/>
-            <value enum="SHIFT_JIS" description="SHIFT_JIS"/>
-            <value enum="UTF-8" description="UTF_8"/>
-        </field>
-        <field name="EncodedTextLen" number="354" type="LENGTH"/>
-        <field name="EncodedText" number="355" type="DATA"/>
-        <field name="LastMsgSeqNumProcessed" number="369" type="SEQNUM"/>
-        <field name="RefTagID" number="371" type="INT"/>
-        <field name="RefMsgType" number="372" type="STRING"/>
-        <field name="SessionRejectReason" number="373" type="INT">
-            <value description="INVALID_TAG_NUMBER" enum="0"/>
-            <value description="REQUIRED_TAG_MISSING" enum="1"/>
-            <value description="SENDINGTIME_ACCURACY_PROBLEM" enum="10"/>
-            <value description="INVALID_MSGTYPE" enum="11"/>
-            <value description="XML_VALIDATION_ERROR" enum="12"/>
-            <value description="TAG_APPEARS_MORE_THAN_ONCE" enum="13"/>
-            <value description="TAG_SPECIFIED_OUT_OF_REQUIRED_ORDER" enum="14"/>
-            <value description="REPEATING_GROUP_FIELDS_OUT_OF_ORDER" enum="15"/>
-            <value description="INCORRECT_NUMINGROUP_COUNT_FOR_REPEATING_GROUP" enum="16"/>
-            <value description="NON_DATA_VALUE_INCLUDES_FIELD_DELIMITER" enum="17"/>
-            <value description="TAG_NOT_DEFINED_FOR_THIS_MESSAGE_TYPE" enum="2"/>
-            <value description="UNDEFINED_TAG" enum="3"/>
-            <value description="TAG_SPECIFIED_WITHOUT_A_VALUE" enum="4"/>
-            <value description="VALUE_IS_INCORRECT" enum="5"/>
-            <value description="INCORRECT_DATA_FORMAT_FOR_VALUE" enum="6"/>
-            <value description="DECRYPTION_PROBLEM" enum="7"/>
-            <value description="SIGNATURE_PROBLEM" enum="8"/>
-            <value description="COMPID_PROBLEM" enum="9"/>
-            <value description="OTHER" enum="99"/>
-        </field>
-        <field name="MaxMessageSize" number="383" type="LENGTH"/>
-        <field name="NoMsgTypes" number="384" type="NUMINGROUP"/>
-        <field name="MsgDirection" number="385" type="CHAR">
-            <value description="RECEIVE" enum="R"/>
-            <value description="SEND" enum="S"/>
-        </field>
-        <field name="TestMessageIndicator" number="464" type="BOOLEAN"/>
-        <field name="Username" number="553" type="STRING"/>
-        <field name="Password" number="554" type="STRING"/>
-        <field name="OTP" number="20000" type="STRING"/>
-        <field name="NoHops" number="627" type="NUMINGROUP"/>
-        <field name="HopCompID" number="628" type="STRING"/>
-        <field name="HopSendingTime" number="629" type="UTCTIMESTAMP"/>
-        <field name="HopRefID" number="630" type="SEQNUM"/>
-        <field name="NextExpectedMsgSeqNum" number="789" type="SEQNUM"/>
-        <field name="ApplVerID" number="1128" type="STRING">
-            <value description="FIX27" enum="0"/>
-            <value description="FIX30" enum="1"/>
-            <value description="FIX40" enum="2"/>
-            <value description="FIX41" enum="3"/>
-            <value description="FIX42" enum="4"/>
-            <value description="FIX43" enum="5"/>
-            <value description="FIX44" enum="6"/>
-            <value description="FIX50" enum="7"/>
-            <value description="FIX50SP1" enum="8"/>
-            <value description="FIX50SP2" enum="9"/>
-        </field>
-        <field name="CstmApplVerID" number="1129" type="STRING"/>
-        <field name="RefApplVerID" number="1130" type="STRING"/>
-        <field name="RefCstmApplVerID" number="1131" type="STRING"/>
-        <field name="DefaultApplVerID" number="1137" type="STRING"/>
         <field number="1" name="Account" type="STRING"/>
         <field number="2" name="AdvId" type="STRING"/>
         <field number="3" name="AdvRefID" type="STRING"/>
@@ -9729,5 +9499,6 @@
         <field number="9995" name="SpotValueDateForNDF" type="LOCALMKTDATE"/>
         <field number="9996" name="ContractPositionNumber" type="INT"/>
         <field number="29500" name="NumericOrderID" type="STRING"/>
+        <field number="20000" name="OTP" type="STRING"/>
     </fields>
 </fix>

--- a/src/util/definition-factory.ts
+++ b/src/util/definition-factory.ts
@@ -3,7 +3,7 @@ import { FixDefinitions } from '../dictionary/definition'
 import { GetJsFixLogger, makeEmptyLogger } from '../config'
 import * as path from 'path'
 import * as fs from 'fs'
-import { FixXsdParser, QuickFixXmlFileParser, RepositoryXmlParser } from '../dictionary/parser'
+import { FixXsdParser, QuickFixGraphFileParser, RepositoryXmlParser } from '../dictionary/parser'
 import { IDictionaryPath } from './dictionary-path'
 import { FileDuplex } from '../transport'
 
@@ -32,7 +32,7 @@ export class DefinitionFactory {
     } else if (fs.lstatSync(path).isDirectory()) {
       parser = new RepositoryXmlParser(path, getLogger)
     } else {
-      parser = new QuickFixXmlFileParser(() => new FileDuplex(path), getLogger)
+      parser = new QuickFixGraphFileParser(() => new FileDuplex(path), getLogger)
     }
     return parser
   }


### PR DESCRIPTION
## Summary

Final piece of Phase 6: the graph-based QuickFix XML parser is now the default. \`DefinitionFactory.getParser()\` instantiates \`QuickFixGraphFileParser\` for QuickFix XML dictionaries.

- Added \`QuickFixGraphFileParser\` — a thin adapter that extends \`FixParser\` and matches the legacy \`(MakeDuplex, GetJsFixLogger)\` constructor signature, so it's a drop-in replacement
- Switched \`DefinitionFactory\` to use it
- Legacy \`QuickFixXmlFileParser\` remains exported for backward compatibility

## Two legacy parser bugs surfaced and fixed

The graph parser's stricter handling exposed two real bugs in the legacy parser that tests had been silently codifying:

### 1. Duplicate definitions in test fixture
\`src/test/env/data/fix5-mod.xml\` contained:
- A redundant 215-line "admin fields" block duplicating 62 fields already in the canonical fields section (BeginSeqNo, BeginString, etc.)
- \`HopGrp\` and \`MsgTypeGrp\` components defined twice

The legacy parser silently kept the last definition; the graph parser's validator correctly flags duplicates. Fix: removed the redundant blocks (preserved the unique \`OTP\` custom tag at number 20000).

### 2. Wrong required flag in legacy parser
\`qf-50sp2-dict.test.ts\` asserted \`Instrument\` and \`TrdCapRptSideGrp\` as \`required=false\` in TradeCaptureReport (35=AE). The FIX50SP2 dictionary clearly says \`required='Y'\` for both — the legacy parser was producing the wrong value somewhere. Fix: updated the assertions to match the correct graph parser output, and switched \`getTrimDefinitions\` in the same file to use \`QuickFixGraphFileParser\` for consistency.

## Test plan
- [x] All 533 tests pass with graph parser as default
- [x] Comparison tests against legacy parser still pass (graph is superset)
- [x] Trim round-trip tests still pass
- [x] No production code uses the legacy parser anymore

## Deferred to follow-up
\`parse-progress.ts\`, \`parse-state.ts\`, and the legacy \`QuickFixXmlFileParser\` are NOT yet deleted. Defer to a cleanup PR after a release cycle to give downstream consumers time to migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)