### PR TITLE
fix: update file store sender sequence on each outbound message

### DIFF
--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -286,6 +286,10 @@ export abstract class AsciiSession extends FixSession {
         // Never block sends on store errors
         this.sessionLogger.warning(`failed to store message seq=${seqNum}: ${e.message}`)
       })
+      // Update store's sender sequence number (next outgoing seq = seqNum + 1)
+      this.sessionStore.setSenderSeqNum(seqNum + 1).catch((e: Error) => {
+        this.sessionLogger.warning(`failed to update sender seq: ${e.message}`)
+      })
     }
   }
 


### PR DESCRIPTION
## Summary
`txOnEncoded` stored the message body but never called `sessionStore.setSenderSeqNum` — the sender sequence in the file store stayed at 1 forever. Recovery across restarts couldn't restore the correct outbound sequence number.

Matches C# `AsciiSession.StoreEncodedMessage` which calls `m_sessionStore.SetSenderSeqNum(seqNum + 1)` on every encoded message.

## Found by
The jspf-demo `client-bounce` scenario test — sender sequences weren't progressing between runs, causing the recovery test to fail.

## Test plan
- [x] All 533 existing tests pass
- [x] Verified file store `.seqnums` now shows correct sender sequence after session

🤖 Generated with [Claude Code](https://claude.com/claude-code)