### PR TITLE
fix: prevent double-dispatch of Logon/ResendRequest on sequence gap

### DIFF
--- a/src/test/ascii/session.test.ts
+++ b/src/test/ascii/session.test.ts
@@ -234,6 +234,34 @@ test('out of seq logout', async () => {
   expect(sviews[1].segment.name).toEqual('Logout')
 })
 
+// Regression test for #134: initiator receives Logon-with-gap should not crash.
+// Simulates peer responding to Logon with a high sequence number (gap in received sequence).
+// Before fix: checkSeqNo called peerLogon (advancing state), returned true, then onSessionMsg
+// tried peerLogon again → "state InitiationLogonReceived is illegal for Logon" → terminate.
+function mutateServerLogonSeqToCreateGap (_: ISessionDescription, type: string, o: ILooseObject): ILooseObject {
+  switch (type) {
+    case 'StandardHeader': {
+      const hdr = o as IStandardHeader
+      // Bump the server's Logon response seq to 5, creating a gap for the client (expects 1)
+      if (hdr.MsgSeqNum === 1 && hdr.MsgType === MsgType.Logon) {
+        hdr.MsgSeqNum = 5
+      }
+      break
+    }
+  }
+  return o
+}
+
+test('logon with sequence gap should not crash (issue #134)', async () => {
+  experiment.serverFactory.mutator = mutateServerLogonSeqToCreateGap
+  await runSkeletons()
+  const cviews = experiment.client.views
+  // Client should have received at least the logon (seq=5) without crashing.
+  // The session should establish and eventually logout normally.
+  expect(cviews.length).toBeGreaterThanOrEqual(1)
+  expect(cviews[0].segment.name).toEqual('Logon')
+})
+
 function countOfType (type: string, views: MsgView[]): number {
   return views.reduce((c: number, v: MsgView) => {
     return v.segment.name === type ? c + 1 : c

--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -130,11 +130,16 @@ export abstract class AsciiSession extends FixSession {
             }
           }
 
-          // Accept the current message — don't block waiting for gap fill.
-          // The gap will be filled by the resend response, but this message is valid.
-          ret = true
+          // Update sequence state regardless — the gap-triggering message is valid.
           state.lastPeerMsgSeqNum = seqNo
           this.coordinator.onMessageReceived(seqNo, false)
+
+          // Logon and ResendRequest were already fully handled above (peerLogon / onResendRequest).
+          // Don't return true for them — they must not be dispatched to onSessionMsg again.
+          // Application messages (and everything else) should be forwarded normally.
+          if (msgType !== MsgType.Logon && msgType !== MsgType.ResendRequest) {
+            ret = true
+          }
         } else {
           ret = true
           state.lastPeerMsgSeqNum = seqNo


### PR DESCRIPTION
## Problem

When the peer responds to Logon with a sequence gap (\`seqDelta > 1\`), \`checkSeqNo\` already handles certain messages in-place:
- **Logon**: calls \`peerLogon(view)\`, advancing state past \`InitiationLogonSent\`
- **ResendRequest**: calls \`onResendRequest(view)\`

PR #122 (Phase 5A) changed the gap path to set \`ret = true\` ("accept the current message"), which caused these messages to **also** flow through to \`onSessionMsg\`. For Logon, \`onSessionMsg\` calls \`okForLogon()\` which checks \`state === InitiationLogonSent\` — but \`peerLogon\` already moved the state to \`InitiationLogonReceived\`, so \`okForLogon()\` returns false and the session terminates with:

> \`state InitiationLogonReceived is illegal for Logon\`

This is a regression from v4.x where all gap-triggering messages returned \`ret = false\`, preventing double-dispatch.

## Fix

Only set \`ret = true\` for messages that weren't already handled in \`checkSeqNo\`. Logon and ResendRequest return false (already fully processed), everything else returns true (needs forwarding to \`onSessionMsg\` / application).

Sequence state (\`lastPeerMsgSeqNum\`, coordinator) is still updated for all message types.

## Test plan
- [x] All 533 existing tests pass
- [x] Logon-with-gap scenario no longer causes terminate

Fixes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)