### PR TITLE
fix: bound tag store growth to prevent heap OOM on misaligned stream (#143)

### DIFF
--- a/src/buffer/ascii/ascii-parser.ts
+++ b/src/buffer/ascii/ascii-parser.ts
@@ -30,7 +30,8 @@ export class AsciiParser extends MsgParser {
 
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig,
     @inject(DITokens.readStream) public readonly readStream: Readable | null,
-    @inject(DITokens.ParseBuffer) protected readonly receivingBuffer: ElasticBuffer) {
+    @inject(DITokens.ParseBuffer) protected readonly receivingBuffer: ElasticBuffer,
+    @inject(DITokens.maxMessageLen) public readonly maxMessageLen: number = 160 * 1024) {
     super()
 
     this.delimiter = config.delimiter ?? AsciiChars.Soh
@@ -38,7 +39,7 @@ export class AsciiParser extends MsgParser {
     this.id = AsciiParser.nextId++
     this.segmentParser = config.sessionContainer.resolve<AsciiSegmentParser>(AsciiSegmentParser)
     this.state = config.sessionContainer.resolve<AsciiParserState>(AsciiParserState)
-    this.state.locations = new Tags(this.receivingBuffer.size / 10)
+    this.state.locations = new Tags(this.receivingBuffer.size / 10, this.maxMessageLen)
     this.state.definitions = this.config.definitions
     this.state.beginMessage()
     if (readStream !== null) {

--- a/src/buffer/tag/tags.ts
+++ b/src/buffer/tag/tags.ts
@@ -8,10 +8,11 @@ export class Tags {
   public static readonly CheckSumTag: number = MsgTag.CheckSum
   public static readonly MsgTag: number = MsgTag.MsgType
 
-  public tagPos: TagPos[] = new Array(this.startingLength)
+  public tagPos: TagPos[] = new Array(Math.min(this.startingLength, this.maxLength))
   public nextTagPos: number = 0
 
-  constructor (public readonly startingLength: number = 30 * 1000) {
+  constructor (public readonly startingLength: number = 30 * 1000,
+    public readonly maxLength: number = 1024 * 1024) {
   }
 
   public static toJSType (tagType: TagType): string {
@@ -128,7 +129,10 @@ export class Tags {
   }
 
   private expand (): void {
-    const size = this.tagPos.length * 2
+    if (this.tagPos.length >= this.maxLength) {
+      throw new Error(`tag count exceeds maximum of ${this.maxLength} - message too large or stream misaligned`)
+    }
+    const size = Math.min(this.tagPos.length * 2, this.maxLength)
     const tagPos = new Array(size)
     for (let i = 0; i < this.tagPos.length; ++i) {
       tagPos[i] = this.tagPos[i]

--- a/src/test/ascii/issue-143-unbounded-tags.test.ts
+++ b/src/test/ascii/issue-143-unbounded-tags.test.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata'
+
+import { Tags } from '../../buffer/tag/tags'
+import { AsciiParser } from '../../buffer/ascii'
+import { StringDuplex, StringDuplexTraits } from '../../transport'
+import { Setup } from '../env/setup'
+
+/**
+ * Reproduction for https://github.com/TimelordUK/jspurefix/issues/143
+ *
+ * The tag store grew with no upper bound, so a misaligned or oversized stream
+ * that never reaches a frame boundary could drive an unbounded new Array(N)
+ * and crash the process with a fatal V8 heap OOM.  Growth is now capped and
+ * an over-long message is rejected with a thrown error instead.
+ */
+
+let setup: Setup
+beforeAll(async () => {
+  setup = new Setup()
+  await setup.init()
+}, 45000)
+
+test('tag store throws once growth would exceed the maximum', () => {
+  const tags = new Tags(2, 4)
+  for (let i = 0; i < 4; ++i) {
+    tags.store(0, 1, i)
+  }
+  expect(() => { tags.store(0, 1, 4) }).toThrow(/exceeds maximum/)
+})
+
+test('misaligned stream is rejected rather than growing tags unbounded', async () => {
+  const header = '8=FIX4.4|9=101|35=A|'
+  let stream = header
+  for (let i = 0; i < 64; ++i) {
+    stream += `${100 + i}=x|`
+  }
+  const parser = new AsciiParser(setup.client.config,
+    new StringDuplex(stream, StringDuplexTraits.Terminate).readable,
+    setup.client.rxBuffer,
+    16)
+  await expect(new Promise((resolve, reject) => {
+    parser.on('error', (e: Error) => { reject(e) })
+    parser.on('done', () => { resolve(null) })
+    parser.on('msg', () => { resolve(null) })
+  })).rejects.toThrow(/exceeds maximum/)
+})
+
+test('a normal message within the maximum still parses', async () => {
+  const res = await setup.client.parseText('8=FIX4.4|9=101|35=A|')
+  expect(res.event).toEqual('done')
+})


### PR DESCRIPTION
Fixes #143.

The ASCII parser's tag store (`Tags`) grew with no upper bound: `tagPos` started at 30k and `expand()` doubled `new Array(size)` forever. A malformed/oversized frame, or a stream that desyncs and never reaches a valid frame boundary, drives that allocation until V8 aborts with a fatal heap OOM (`Runtime_NewArray → ArrayConstructInitializeElements → NewFixedArray`).

This adds a `maxLength` bound to `Tags` (clamps the initial allocation, caps the doubling, and throws once growth would exceed it). `AsciiParser` supplies the bound from the existing `maxMessageLen` setting (160KB default for ASCII sessions). Because the shortest possible field is ~4 bytes, a tag-count cap equal to `maxMessageLen` cannot reject any legitimate message but does turn an unbounded allocation into a clean thrown parse error. The `new Array(groupCount())` in `msg-view.ts` is bounded transitively by the now-capped store.

Adds `issue-143-unbounded-tags.test.ts` covering the cap on the store directly, a misaligned stream being rejected, and a normal message still parsing.
