### PR TITLE
test(tags): clamp clone to maxLength + cover initial-alloc clamp (follow-up to #144)

### DIFF
--- a/src/buffer/tag/tags.ts
+++ b/src/buffer/tag/tags.ts
@@ -102,7 +102,7 @@ export class Tags {
 
   public clone (): Tags {
     const next: number = this.nextTagPos
-    const cloned: Tags = new Tags(next)
+    const cloned: Tags = new Tags(next, this.maxLength)
     cloned.nextTagPos = next
     for (let i = 0; i < next; ++i) {
       cloned.tagPos[i] = this.tagPos[i].clone()

--- a/src/test/ascii/issue-143-unbounded-tags.test.ts
+++ b/src/test/ascii/issue-143-unbounded-tags.test.ts
@@ -49,3 +49,19 @@ test('a normal message within the maximum still parses', async () => {
   const res = await setup.client.parseText('8=FIX4.4|9=101|35=A|')
   expect(res.event).toEqual('done')
 })
+
+test('initial allocation is clamped to the maximum when starting length is larger', () => {
+  const tags = new Tags(1000, 4)
+  expect(tags.tagPos.length).toEqual(4)
+})
+
+test('clone preserves the maximum so a clone cannot grow unbounded either', () => {
+  const tags = new Tags(2, 4)
+  for (let i = 0; i < 3; ++i) {
+    tags.store(0, 1, i)
+  }
+  const cloned = tags.clone()
+  expect(cloned.maxLength).toEqual(4)
+  cloned.store(0, 1, 3)
+  expect(() => { cloned.store(0, 1, 4) }).toThrow(/exceeds maximum/)
+})


### PR DESCRIPTION
Follow-up to #144 (issue #143).

#144 was merged from a fork, so these additional tests couldn't be pushed onto that PR branch. They land the same intent on top of master:

- **`Tags.clone()` now propagates `maxLength`** — previously a clone fell back to the default 1M cap; now a cloned store inherits the same bound, so it cannot grow unbounded either.
- Test: initial allocation is clamped to `maxLength` when `startingLength` exceeds it (`new Array(Math.min(...))`).
- Test: `clone()` preserves the cap and still throws once growth would exceed it.

All 5 tests in `issue-143-unbounded-tags.test.ts` pass; full ascii suite (231 tests) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)