### PR TITLE
fix(session): detach waitPromise listeners on settle (#146)

### DIFF
--- a/src/test/session/issue-146-listener-leak.test.ts
+++ b/src/test/session/issue-146-listener-leak.test.ts
@@ -1,0 +1,74 @@
+import 'reflect-metadata'
+
+import { StringDuplex, StringDuplexTraits } from '../../transport'
+import { MsgTransport } from '../../transport/factory'
+import { SkeletonSession } from '../../sample/tcp/skeleton/skeleton-session'
+import { Setup } from '../env/setup'
+
+/**
+ * Reproduction for https://github.com/TimelordUK/jspurefix/issues/146
+ *
+ * A long-lived FixSession is reused across transport reconnects (the design used
+ * by RecoveringTcpInitiator).  Each reconnect calls session.run() -> waitPromise(),
+ * which registered a fresh pair of 'error'/'done' listeners on the session emitter
+ * with `on` and never detached them.  The promise settles only once, so:
+ *
+ *   - the listener that fired stayed attached (it used `on`, not `once`), and
+ *   - the sibling listener that never fired was orphaned forever.
+ *
+ * After ~10 reconnect cycles Node prints MaxListenersExceededWarning, and every
+ * orphaned listener retains a closure over the settled promise/transport - a real
+ * (slow) memory leak for the lifetime of the process.
+ */
+
+let setup: Setup
+
+beforeAll(async () => {
+  setup = new Setup()
+  await setup.init()
+}, 45000)
+
+function newTransport (config: any): MsgTransport {
+  const duplex = new StringDuplex('', StringDuplexTraits.None)
+  return new MsgTransport(0, config, duplex)
+}
+
+async function waitFor (predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition')
+    }
+    await new Promise<void>(resolve => { setImmediate(resolve) })
+  }
+}
+
+/**
+ * Drive a single reconnect cycle against one reused session: run the session on a
+ * fresh transport, then settle the run promise the way a clean logout would by
+ * emitting 'done'.  AsciiSession.run() awaits store initialisation before
+ * waitPromise() attaches its listeners, so wait for the 'done' listener to appear
+ * before emitting.
+ */
+async function reconnectCycle (session: SkeletonSession, config: any): Promise<void> {
+  const run = session.run(newTransport(config))
+  await waitFor(() => session.listenerCount('done') > 0)
+  session.emit('done')
+  await run
+}
+
+test('session listeners do not accumulate across repeated reconnects', async () => {
+  // acceptor session so waitPromise does not attempt to send a logon
+  const session = new SkeletonSession(setup.serverConfig, 1, false)
+
+  const cycles = 15
+  for (let i = 0; i < cycles; ++i) {
+    await reconnectCycle(session, setup.serverConfig)
+  }
+
+  // Before the fix these climbed by one per reconnect (== cycles) and Node emitted
+  // MaxListenersExceededWarning past 10.  After the fix both handlers are detached
+  // when the promise settles, so the counts stay bounded regardless of reconnects.
+  expect(session.listenerCount('done')).toBeLessThanOrEqual(1)
+  expect(session.listenerCount('error')).toBeLessThanOrEqual(1)
+})

--- a/src/transport/session/fix-session.ts
+++ b/src/transport/session/fix-session.ts
@@ -110,14 +110,26 @@ export abstract class FixSession extends events.EventEmitter {
         this.setState(SessionState.WaitingForALogon)
       }
 
-      this.on('error', (e: Error) => {
+      // Use named handlers and detach BOTH when the promise settles.  Only one of
+      // 'error'/'done' fires per run; without removing the sibling the unfired
+      // listener would leak on every reconnect (issue #146).  `once` alone is not
+      // enough for the same reason — the sibling never fires, so never self-detaches.
+      const cleanup = (): void => {
+        this.removeListener('error', onError)
+        this.removeListener('done', onDone)
+      }
+      const onError = (e: Error): void => {
+        cleanup()
         logger.error(e)
         reject(e)
-      })
-
-      this.on('done', () => {
+      }
+      const onDone = (): void => {
+        cleanup()
         resolve(this.transport?.id)
-      })
+      }
+
+      this.on('error', onError)
+      this.on('done', onDone)
     })
   }
 


### PR DESCRIPTION
Fixes #146

## Problem

`FixSession.waitPromise()` registered a fresh `error`/`done` listener pair on the session emitter with `on` on **every** `run()`. A long-lived `FixSession` reused across reconnects (the `RecoveringTcpInitiator` design) settles each run promise only once, so on each reconnect:

- the listener that fired stayed attached (`on`, not `once`), and
- its sibling — which never fires for that run — was orphaned forever.

`reset()` never detached them, so they accumulated for the process lifetime. After ~10 reconnect cycles Node prints:

```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 done listeners added to [MarketSession]. MaxListeners is 10.
```

Beyond the warning, each orphaned listener retains a closure over the settled promise and transport — a genuine (slow) memory leak.

## Fix

Use named `onError`/`onDone` handlers and remove **both** when the promise settles. As noted in the issue, `once` alone is not sufficient: the sibling event never fires per run, so it never self-detaches and must be removed explicitly.

## Test

Adds `src/test/session/issue-146-listener-leak.test.ts`, which reuses a single session across 15 reconnect cycles and asserts the `done`/`error` listener counts stay bounded (`<= 1`). Before the fix it reproduced the exact issue symptom — the real `MaxListenersExceededWarning` and a listener count of 15 (one per cycle).

## Validation

- New repro test passes; no listener warning emitted.
- End-to-end `SkeletonRunner` suite (`ascii/session.test.ts`), reconnect/reset suite (`issue-140`), and `logon` suite all pass — real logon/logout/reconnect flows unaffected.
- Full suite: **541/541 tests pass**; `tsc --noEmit` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)