### PR TITLE
fix(tcp): honour rejectUnauthorized: false in TcpInitiator (#94)

### DIFF
--- a/src/test/tcp/issue-94-reject-unauthorized.test.ts
+++ b/src/test/tcp/issue-94-reject-unauthorized.test.ts
@@ -1,0 +1,110 @@
+import 'reflect-metadata'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import * as tls from 'tls'
+import { execFileSync } from 'child_process'
+import { SessionContainer } from '../../runtime'
+import { DITokens } from '../../runtime/di-tokens'
+import { IJsFixConfig } from '../../config'
+import { ISessionDescription } from '../../transport'
+import { TcpInitiator } from '../../transport/tcp/tcp-initiator'
+
+/**
+ * Reproduction for https://github.com/TimelordUK/jspurefix/issues/94
+ *
+ * TcpInitiator.tlsDuplex() unconditionally rejects the connection whenever
+ * `tlsSocket.authorized` is false - regardless of what `rejectUnauthorized` was set to in the
+ * caller's TLS connection options. This makes `rejectUnauthorized: false` a no-op: there is no
+ * way to connect to a counterparty presenting a self-signed / privately-issued certificate we
+ * can't otherwise verify, even though that is exactly what `rejectUnauthorized: false` is for.
+ *
+ * (Encountered for real connecting to a FIX counterparty whose certificate is issued by their own
+ * private CA, whose root we don't have - `fixparser`, by contrast, sets `rejectUnauthorized:
+ * false` and simply proceeds, which is the behaviour this test asserts jspurefix should match.)
+ */
+
+// Generated fresh into a temp dir rather than checked in, so no key material lives in the repo.
+const certDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jspurefix-issue-94-'))
+const selfSignedKeyPath = path.join(certDir, 'self-signed.key')
+const selfSignedCertPath = path.join(certDir, 'self-signed.crt')
+execFileSync('openssl', [
+  'req', '-x509', '-newkey', 'rsa:2048',
+  '-keyout', selfSignedKeyPath,
+  '-out', selfSignedCertPath,
+  '-days', '1',
+  '-nodes',
+  '-subj', '/CN=localhost'
+])
+const selfSignedKey = fs.readFileSync(selfSignedKeyPath)
+const selfSignedCert = fs.readFileSync(selfSignedCertPath)
+
+afterAll(() => {
+  fs.rmSync(certDir, { recursive: true, force: true })
+})
+
+async function withSelfSignedTlsServer<T> (fn: (port: number) => Promise<T>): Promise<T> {
+  const server = tls.createServer({ key: selfSignedKey, cert: selfSignedCert }, (socket) => {
+    socket.end()
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  const port = typeof address === 'object' && address !== null ? address.port : 0
+  try {
+    return await fn(port)
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
+async function makeConfig (port: number, rejectUnauthorized: boolean): Promise<IJsFixConfig> {
+  const description: ISessionDescription = {
+    application: {
+      type: 'initiator',
+      name: 'issue_94_test',
+      protocol: 'ascii',
+      dictionary: 'repo44',
+      tcp: {
+        host: '127.0.0.1',
+        port,
+        tls: {
+          nodeTlsConnectionOptions: {
+            rejectUnauthorized
+          }
+        }
+      }
+    },
+    EncryptMethod: 0,
+    ResetSeqNumFlag: true,
+    HeartBtInt: 30,
+    SenderCompId: 'TEST_SENDER',
+    TargetCompID: 'TEST_TARGET',
+    BeginString: 'FIX.4.4'
+  } as unknown as ISessionDescription
+
+  const fixContainer = new SessionContainer()
+  fixContainer.registerGlobal('error')
+  const sessionContainer = await fixContainer.makeSystem(description)
+  return sessionContainer.resolve<IJsFixConfig>(DITokens.IJsFixConfig)
+}
+
+describe('issue #94 - TcpInitiator ignores rejectUnauthorized: false', () => {
+  it('connects to a self-signed-cert peer when rejectUnauthorized is false', async () => {
+    await withSelfSignedTlsServer(async (port) => {
+      const config = await makeConfig(port, false)
+      const initiator = new TcpInitiator(config)
+      // Before the fix: this rejects with DEPTH_ZERO_SELF_SIGNED_CERT despite
+      // rejectUnauthorized: false. After the fix: it resolves normally.
+      await expect(initiator.connect(5)).resolves.toBeDefined()
+      initiator.end()
+    })
+  }, 8000)
+
+  it('still rejects a self-signed-cert peer when rejectUnauthorized is true (default security preserved)', async () => {
+    await withSelfSignedTlsServer(async (port) => {
+      const config = await makeConfig(port, true)
+      const initiator = new TcpInitiator(config)
+      await expect(initiator.connect(1)).rejects.toBeDefined()
+    })
+  })
+})

--- a/src/transport/tcp/tcp-initiator.ts
+++ b/src/transport/tcp/tcp-initiator.ts
@@ -123,12 +123,20 @@ export class TcpInitiator extends FixInitiator {
           tlsSocket = tlsConnect(connectionOptions, () => {
             if (!tlsSocket) return null
             this.logger.info(`client connected ${tlsSocket.authorized ? 'authorized' : 'unauthorized'}`)
-            if (!tlsSocket.authorized) {
+            // https://github.com/TimelordUK/jspurefix/issues/94 - honour rejectUnauthorized:
+            // false rather than always rejecting on an unauthorized cert. Node's tls.connect()
+            // never throws for an unauthorized peer by itself; it's the caller's job to decide
+            // what to do with tlsSocket.authorized, and rejectUnauthorized is how a caller opts
+            // out of that check - so only reject here when the caller didn't opt out.
+            if (!tlsSocket.authorized && connectionOptions.rejectUnauthorized !== false) {
               const error = tlsSocket.authorizationError
               this.logger.warning(`rejecting from state ${this.state} authorizationError ${error}`)
               tlsSocket.end()
               reject(error)
             } else {
+              if (!tlsSocket.authorized) {
+                this.logger.warning(`proceeding despite unauthorized TLS peer (rejectUnauthorized: false): ${tlsSocket.authorizationError}`)
+              }
               tlsSocket.setEncoding('utf8')
               const tlsDuplex = new TcpDuplex(tlsSocket)
               if (tcp?.tls?.enableTrace) {


### PR DESCRIPTION
Fixes #94

## Problem

`TcpInitiator.tlsDuplex()` unconditionally rejects the connection whenever `tlsSocket.authorized` is `false` — regardless of what `rejectUnauthorized` was set to in the caller's TLS connection options. This makes `rejectUnauthorized: false` a no-op: there's no way to connect to a counterparty presenting a certificate that can't be chain-verified (self-signed, or issued by a private CA whose root isn't available to the client) — even though that's exactly the case `rejectUnauthorized: false` exists for. Node's own `tls.connect()` never throws for an unauthorized peer on its own; `authorized`/`authorizationError` are exposed precisely so the caller can decide, and `rejectUnauthorized` is how a caller opts out of enforcing it.

Same root cause as discussed in #94, where the proposed fix is exactly this guard — it looks like that never made it into a PR.

## Fix

Only reject on `!tlsSocket.authorized` when `connectionOptions.rejectUnauthorized !== false`. When the caller has explicitly opted out, log a warning and proceed instead of rejecting.

## Test

Adds `src/test/tcp/issue-94-reject-unauthorized.test.ts`:
- Starts a local TLS server presenting a self-signed cert (generated fresh at test time into a temp dir, not checked into the repo).
- Asserts `TcpInitiator.connect()` **resolves** when `rejectUnauthorized: false` is set — before the fix this hung until `TcpInitiator`'s own connect-timeout, rejecting with a generic timeout error (the underlying TLS rejection was silently retried forever).
- Asserts `TcpInitiator.connect()` **still rejects** when `rejectUnauthorized` is left at its default (`true`) — confirms the fix doesn't weaken default certificate verification, only honours an explicit opt-out.

## Validation

- New repro test passes both cases.
- Full suite: 543/543 tests pass; `tsc --noEmit` clean.