### PR TITLE
Keep a custom session message factory in per-session scopes (#87)

### DIFF
--- a/docs/acceptor.md
+++ b/docs/acceptor.md
@@ -61,6 +61,30 @@ Writing `makeSession: () => new MyServer(config)` closes over the launcher's con
 and opts the application out of per-session isolation. It still works for a single
 counterparty; it does not work for several.
 
+### Custom session message factories
+
+If you supply your own `ISessionMsgFactory` — usually by overriding
+`SessionContainer.makeSessionFactory` to stamp extra header fields — the scope needs
+a copy of *your* factory bound to that session's description, not a stock one.
+
+Extending `ASessionMsgFactory` (or `AsciiSessionMsgFactory` / `FixmlSessionMsgFactory`)
+gets this for free: the default `cloneFor` reconstructs through the concrete
+constructor, so a subclass taking `(description, mutator)` needs no extra work.
+Override `cloneFor` if your constructor takes anything else:
+
+```ts
+class BrokerMsgFactory extends AsciiSessionMsgFactory {
+  constructor (description: ISessionDescription, private readonly desk: string) {
+    super(description)
+  }
+
+  // the default clone would not know about `desk`
+  public override cloneFor (description: ISessionDescription): ISessionMsgFactory {
+    return new BrokerMsgFactory(description, this.desk)
+  }
+}
+```
+
 ## The session registry
 
 FIX permits exactly one active session per `SessionId`. `SessionRegistry` enforces

--- a/src/runtime/session-scope.ts
+++ b/src/runtime/session-scope.ts
@@ -63,9 +63,19 @@ function cloneBuffer (parent: DependencyContainer, token: DITokens): ElasticBuff
   return new ElasticBuffer(existing.size)
 }
 
+/**
+ * The scope needs a factory bound to *its* description, because the outbound header
+ * carries this session's comp ids.  Applications may supply their own factory (by
+ * overriding SessionContainer.makeSessionFactory), and that must survive into the
+ * per-session scope - building a stock one here would silently drop custom header
+ * handling on the acceptor path.  See issue #87.
+ */
 function makeSessionMsgFactory (
   description: ISessionDescription,
   current: ISessionMsgFactory | null): ISessionMsgFactory {
+  if (current?.cloneFor) {
+    return current.cloneFor(description)
+  }
   const ascii = description.application?.protocol === 'ascii'
   const mutator = (current as any)?.mutator ?? null
   return ascii

--- a/src/test/session/custom-session-msg-factory.test.ts
+++ b/src/test/session/custom-session-msg-factory.test.ts
@@ -1,0 +1,115 @@
+import 'reflect-metadata'
+
+import { Setup } from '../env/setup'
+import { makeSessionScope } from '../../runtime/session-scope'
+import { AsciiSessionMsgFactory } from '../../transport/ascii/ascii-session-msg-factory'
+import { ASessionMsgFactory, ObjectMutator } from '../../transport/session/a-session-msg-factory'
+import { ISessionDescription } from '../../transport/session/session-description'
+import { ISessionMsgFactory } from '../../transport/session/session-msg-factory'
+import { ILooseObject } from '../../collections/collection'
+import { IStandardHeader } from '../../types/FIX4.4/repo'
+import { DITokens } from '../../runtime/di-tokens'
+
+/**
+ * https://github.com/TimelordUK/jspurefix/issues/87
+ *
+ * An application supplies its own session message factory by overriding
+ * SessionContainer.makeSessionFactory - typically to stamp extra header fields a
+ * counterparty demands.  An acceptor builds a factory per accepted connection so
+ * each session's headers carry its own comp ids; that must preserve the
+ * application's factory rather than substituting the stock one, otherwise custom
+ * header handling silently disappears on the acceptor path.
+ */
+
+let setup: Setup
+
+beforeAll(async () => {
+  setup = new Setup()
+  await setup.init()
+}, 45000)
+
+/** the shape an application typically writes - extend the ascii factory */
+class BrokerSessionMsgFactory extends AsciiSessionMsgFactory {
+  public header (msgType: string, seqNum: number, time: Date, overrideData?: Partial<IStandardHeader>): ILooseObject {
+    const h = super.header(msgType, seqNum, time, overrideData)
+    h.OnBehalfOfCompID = 'broker-desk'
+    return h
+  }
+}
+
+/** a factory whose constructor does not take (description, mutator) */
+class UnusualFactory extends ASessionMsgFactory {
+  constructor (description: ISessionDescription, public readonly tag: string) {
+    super(description, null)
+  }
+
+  public override cloneFor (description: ISessionDescription): ISessionMsgFactory {
+    return new UnusualFactory(description, this.tag)
+  }
+
+  public logon (): ILooseObject { return {} }
+  public logout (_msgType: string, _text: string): ILooseObject { return {} }
+  public header (_msgType: string, _seqNum: number, _time: Date): ILooseObject {
+    return { SenderCompID: this.description.SenderCompId, TargetCompID: this.description.TargetCompID }
+  }
+}
+
+describe('custom session message factory', () => {
+  test('survives into a per-connection session scope', () => {
+    const config = { ...setup.serverConfig } as any
+    config.factory = new BrokerSessionMsgFactory(setup.serverConfig.description)
+
+    const scope = makeSessionScope(config, { TargetCompID: 'client-one' })
+
+    expect(scope.factory).toBeInstanceOf(BrokerSessionMsgFactory)
+    const header = scope.factory?.header('A', 1, new Date()) as any
+    // the application's own field is still stamped ...
+    expect(header.OnBehalfOfCompID).toBe('broker-desk')
+    // ... and the header carries this session's target, not the listener's
+    expect(header.TargetCompID).toBe('client-one')
+  })
+
+  test('the scope registers the cloned factory, so the transmitter resolves it', () => {
+    const config = { ...setup.serverConfig } as any
+    config.factory = new BrokerSessionMsgFactory(setup.serverConfig.description)
+
+    const scope = makeSessionScope(config, { TargetCompID: 'client-two' })
+    const registered = scope.sessionContainer.resolve<ISessionMsgFactory>(DITokens.ISessionMsgFactory)
+
+    expect(registered).toBe(scope.factory)
+    expect(registered).toBeInstanceOf(BrokerSessionMsgFactory)
+    expect(registered).not.toBe(config.factory)
+  })
+
+  test('a mutator set on the application factory is carried across', () => {
+    const mutator: ObjectMutator = (_d, _t, o) => ({ ...o, Account: 'desk-7' })
+    const config = { ...setup.serverConfig } as any
+    config.factory = new AsciiSessionMsgFactory(setup.serverConfig.description, mutator)
+
+    const scope = makeSessionScope(config, { TargetCompID: 'client-three' })
+    const header = scope.factory?.header('A', 1, new Date()) as any
+
+    expect(header.Account).toBe('desk-7')
+  })
+
+  test('a factory with its own constructor shape controls its own cloning', () => {
+    const config = { ...setup.serverConfig } as any
+    config.factory = new UnusualFactory(setup.serverConfig.description, 'marker')
+
+    const scope = makeSessionScope(config, { TargetCompID: 'client-four' })
+
+    expect(scope.factory).toBeInstanceOf(UnusualFactory)
+    expect((scope.factory as UnusualFactory).tag).toBe('marker')
+    expect((scope.factory?.header('A', 1, new Date()) as any).TargetCompID).toBe('client-four')
+  })
+
+  test('falls back to the stock factory when none is configured', () => {
+    const config = { ...setup.serverConfig } as any
+    config.factory = null
+
+    const scope = makeSessionScope(config, { TargetCompID: 'client-five' })
+
+    expect(scope.factory).toBeInstanceOf(AsciiSessionMsgFactory)
+    expect((scope.factory?.header('A', 1, new Date()) as any).TargetCompID).toBe('client-five')
+  })
+})

--- a/src/transport/session/a-session-msg-factory.ts
+++ b/src/transport/session/a-session-msg-factory.ts
@@ -20,6 +20,24 @@ export abstract class ASessionMsgFactory implements ISessionMsgFactory {
   protected constructor (public readonly description: ISessionDescription, public mutator: ObjectMutator | null = null) {
   }
 
+  /**
+   * Rebuild this factory against another session description, preserving the
+   * concrete type.  An acceptor needs one factory per accepted connection so that
+   * outbound headers carry that session's comp ids; without preserving the type, an
+   * application's own factory would be silently replaced by the stock one.
+   *
+   * Reconstructing through `this.constructor` covers any subclass whose constructor
+   * takes (description, mutator) - the shape every factory in this library uses.
+   * Override this if yours takes anything else.
+   */
+  public cloneFor (description: ISessionDescription): ISessionMsgFactory {
+    const Ctor = this.constructor as new (
+      description: ISessionDescription,
+      mutator: ObjectMutator | null
+    ) => ISessionMsgFactory
+    return new Ctor(description, this.mutator)
+  }
+
   public reject (msgType: string, seqNo: number, msg: string, reason: number): ILooseObject {
     const o: IReject = {
       RefMsgType: msgType,

--- a/src/transport/session/session-msg-factory.ts
+++ b/src/transport/session/session-msg-factory.ts
@@ -13,4 +13,17 @@ export interface ISessionMsgFactory {
   heartbeat: (testReqId: string) => ILooseObject
   header: (msgType: string, seqNum: number, time: Date, overrideData?: Partial<IStandardHeader>) => ILooseObject
   trailer: (checksum: number) => ILooseObject
+  /**
+   * Produce a factory of this same kind bound to another session description.
+   *
+   * An acceptor builds one of these per accepted connection, because the outbound
+   * header carries that session's comp ids - and under a wildcard TargetCompID the
+   * target is not known until the peer logs on.  Implementing this is what lets an
+   * application's own factory survive into those per-session scopes; without it the
+   * acceptor can only fall back to the stock factory for the protocol.
+   *
+   * ASessionMsgFactory supplies a default that reconstructs via the concrete
+   * constructor, so a subclass taking (description, mutator) needs to do nothing.
+   */
+  cloneFor?: (description: ISessionDescription) => ISessionMsgFactory
 }


### PR DESCRIPTION
Follow-up to #154. Small, contained, but it matters before release.

## The problem

#154 gave every accepted connection its own session message factory, because each session's outbound header must carry its own comp ids — and under a wildcard `TargetCompID` the target is not known until the peer logs on.

`makeSessionScope` built that factory unconditionally from the protocol:

```ts
return ascii
  ? new AsciiSessionMsgFactory(description, mutator)
  : new FixmlSessionMsgFactory(description, mutator)
```

Applications supply their own factory by overriding `SessionContainer.makeSessionFactory` — typically to stamp extra header fields a counterparty demands. That factory was **silently substituted with the stock one, on the acceptor path only**. The output looks correct right up until someone notices a custom header field has gone missing.

## Why this matters now

Found while confirming that the wildcard `TargetCompID` work closes #87. That issue is "one SenderCompID to multiple TargetCompIDs" on a server, and its reporter was advised in 2024 to override the message factory:

> if you have your own overriden version of this then this would need to be updated with something similar

So a custom factory is precisely the configuration #87's reporter is likely to be in. Shipping the multi-client feature while quietly dropping their factory would be a poor trade.

## The fix

`ISessionMsgFactory` gains an optional `cloneFor(description)`. `ASessionMsgFactory` implements it by reconstructing through `this.constructor`, so any subclass taking `(description, mutator)` — the shape every factory in this library uses — is preserved with no change on the application's part:

```ts
class BrokerMsgFactory extends AsciiSessionMsgFactory {
  public header (msgType: string, seqNum: number, time: Date, o?: Partial<IStandardHeader>) {
    const h = super.header(msgType, seqNum, time, o)
    h.OnBehalfOfCompID = 'broker-desk'
    return h
  }
}
// per-session scopes now get a BrokerMsgFactory bound to that session's description
```

A factory whose constructor takes something else overrides `cloneFor` itself. Documented in `docs/acceptor.md`.

## Compatibility

- `cloneFor` is optional on the interface, and the previous construction is the fallback — anything implementing `ISessionMsgFactory` directly keeps working unchanged
- no signature changes to existing methods
- initiators unaffected (session scopes are acceptor-only)

## Verification

- new suite `custom-session-msg-factory.test.ts` — 5 cases: custom type preserved, the scope's DI registration matches, mutators carried across, a non-standard constructor controlling its own cloning, and the stock fallback when no factory is configured
- **confirmed the tests fail without the fix**: 3 of the 5 fail on the previous `session-scope.ts`, pass with it
- full suite 587 pass (was 582), `eslint` clean, `npm run circular` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
