### PR TITLE
lint: clear the remaining eslint errors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,6 +106,8 @@ export default [
       'prefer-template': 'off',
       'radix': 'off',
       'require-unicode-regexp': 'off',
+      // named capture groups need a target of es2018, this package emits es6
+      'prefer-named-capture-group': 'off',
       'promise/avoid-new': 'off',
       'promise/no-multiple-resolved': 'off',
       'import/enforce-node-protocol-usage': 'off',
@@ -114,6 +116,18 @@ export default [
     }
   },
   {
-    ignores: ['dist/**', 'node_modules/**']
+    files: ['src/test/**/*.ts'],
+    rules: {
+      // tests assert a value is present with expect(x).toBeDefined() and then use x!.
+      // the compiler cannot follow that, and rewriting each site as an explicit throw
+      // buries the assertion the test is actually about.
+      '@typescript-eslint/no-non-null-assertion': 'off',
+      // save/restore of a static around an awaited body is not a race in a jest file,
+      // which runs its tests serially.
+      'require-atomic-updates': 'off'
+    }
+  },
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**']
   }
 ]

--- a/src/buffer/ascii/ascii-segment-parser.ts
+++ b/src/buffer/ascii/ascii-segment-parser.ts
@@ -29,10 +29,13 @@ export class AsciiSegmentParser {
   public parse (msgType: string, tags: Tags, last: number): Structure | null {
     // completed segments in that they are fully parsed
     const segments: SegmentDescription[] = []
-    const msgDefinition: MessageDefinition | undefined = this.definitions.message.get(msgType)
-    if (!msgDefinition) {
+    const resolved: MessageDefinition | undefined = this.definitions.message.get(msgType)
+    if (!resolved) {
       return null
     }
+    // narrowing of resolved is not visible inside the hoisted helpers below, so
+    // carry the definition on a const the compiler already sees as non-optional
+    const msgDefinition: MessageDefinition = resolved
     // in process of being discovered and may have any amount of depth
     // i.e. a component containing a repeated group of components
     // with sub-groups of components
@@ -189,7 +192,7 @@ export class AsciiSegmentParser {
       // only build SegmentViews for components detected as fragmented during discover
       // non-fragmented components use their position ranges directly (zero overhead)
       if (fragmentedComponents.size === 0) return
-      const ti = new TagIndex(msgDefinition!, tags, last + 1)
+      const ti = new TagIndex(msgDefinition, tags, last + 1)
       const seen = new Set<string>()
       for (let i = 1; i < segments.length - 1; i++) {
         const seg = segments[i]

--- a/src/dictionary/parser/quickfix/quick-fix-graph-parser.ts
+++ b/src/dictionary/parser/quickfix/quick-fix-graph-parser.ts
@@ -118,8 +118,7 @@ export class QuickFixGraphParser {
     this.parseTrailer(doc)
     this.parseMessages(doc)
 
-    while (this.queue.length > 0) {
-      const node = this.queue.shift()!
+    for (let node = this.queue.shift(); node !== undefined; node = this.queue.shift()) {
       this.work(node)
     }
 

--- a/src/store/file-session-stream-provider.ts
+++ b/src/store/file-session-stream-provider.ts
@@ -32,28 +32,34 @@ export class FileSessionStreamProvider implements ISessionStreamProvider {
   }
 
   openBody (): void {
-    if (this.bodyFd !== null) return
-    this.bodyFd = fs.openSync(this.bodyPath, 'a+')
-    const stat = fs.fstatSync(this.bodyFd)
-    this.bodySize = stat.size
+    this.openBodyFd()
+  }
+
+  /**
+   * open the body file on first use and hand back the descriptor - returning it
+   * keeps callers free of a null check the compiler cannot see through.
+   */
+  private openBodyFd (): number {
+    if (this.bodyFd === null) {
+      this.bodyFd = fs.openSync(this.bodyPath, 'a+')
+      const stat = fs.fstatSync(this.bodyFd)
+      this.bodySize = stat.size
+    }
+    return this.bodyFd
   }
 
   async appendBody (data: Buffer): Promise<number> {
-    if (this.bodyFd === null) {
-      this.openBody()
-    }
+    const fd = this.openBodyFd()
     const offset = this.bodySize
-    fs.writeSync(this.bodyFd!, data, 0, data.length, offset)
+    fs.writeSync(fd, data, 0, data.length, offset)
     this.bodySize += data.length
     return offset
   }
 
   async readBody (offset: number, length: number): Promise<Buffer> {
-    if (this.bodyFd === null) {
-      this.openBody()
-    }
+    const fd = this.openBodyFd()
     const buf = Buffer.alloc(length)
-    fs.readSync(this.bodyFd!, buf, 0, length, offset)
+    fs.readSync(fd, buf, 0, length, offset)
     return buf
   }
 

--- a/src/test/ascii/fixsim.test.ts
+++ b/src/test/ascii/fixsim.test.ts
@@ -31,14 +31,14 @@ test('expect correct message type counts', () => {
     }
     return a
   }, {})
-  expect(counts['A']).toEqual(2)   // Logon
-  expect(counts['0']).toEqual(38)  // Heartbeat
-  expect(counts['6']).toEqual(1)   // IOI
-  expect(counts['1']).toEqual(1)   // TestRequest
-  expect(counts['V']).toEqual(1)   // MarketDataRequest
-  expect(counts['D']).toEqual(1)   // NewOrderSingle
-  expect(counts['8']).toEqual(1)   // ExecutionReport
-  expect(counts['R']).toEqual(1)   // QuoteRequest
+  expect(counts.A).toEqual(2) // Logon
+  expect(counts['0']).toEqual(38) // Heartbeat
+  expect(counts['6']).toEqual(1) // IOI
+  expect(counts['1']).toEqual(1) // TestRequest
+  expect(counts.V).toEqual(1) // MarketDataRequest
+  expect(counts.D).toEqual(1) // NewOrderSingle
+  expect(counts['8']).toEqual(1) // ExecutionReport
+  expect(counts.R).toEqual(1) // QuoteRequest
 })
 
 /*

--- a/src/test/dictionary/dictionary-validator.test.ts
+++ b/src/test/dictionary/dictionary-validator.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import { SaxTreeBuilder } from '../../dictionary/parser/quickfix/sax-tree-builder'
 import { DictionaryValidator } from '../../dictionary/parser/quickfix/dictionary-validator'
-import { ValidationSeverity, DictionaryValidationException } from '../../dictionary/parser/quickfix/validation-error'
+import { ValidationSeverity, DictionaryValidationException, ValidationError } from '../../dictionary/parser/quickfix/validation-error'
 
 const dataRoot = path.join(__dirname, '../../../data')
 
@@ -13,7 +13,7 @@ function validate (xml: string): DictionaryValidator {
   return validator
 }
 
-function errorsWithCode (validator: DictionaryValidator, code: string) {
+function errorsWithCode (validator: DictionaryValidator, code: string): ValidationError[] {
   return validator.errors.filter(e => e.code === code)
 }
 
@@ -364,13 +364,13 @@ describe('DictionaryValidator — throwIfErrors', () => {
   test('throws DictionaryValidationException on errors', () => {
     const v = validate('<fix></fix>')
     expect(v.hasErrors).toBe(true)
-    expect(() => v.throwIfErrors()).toThrow(DictionaryValidationException)
+    expect(() => { v.throwIfErrors() }).toThrow(DictionaryValidationException)
   })
 
   test('does not throw when only warnings', () => {
     const v = validate(validMinimalXml)
     expect(v.hasErrors).toBe(false)
-    expect(() => v.throwIfErrors()).not.toThrow()
+    expect(() => { v.throwIfErrors() }).not.toThrow()
   })
 })
 

--- a/src/test/dictionary/quick-fix-graph-parser.test.ts
+++ b/src/test/dictionary/quick-fix-graph-parser.test.ts
@@ -186,7 +186,7 @@ describe('QuickFixGraphParser — comparison with existing parser', () => {
   })
 })
 
-function collectGroupNames (set: any, acc: Set<string> = new Set(), visited: Set<any> = new Set()): Set<string> {
+function collectGroupNames (set: any, acc = new Set<string>(), visited = new Set<any>()): Set<string> {
   if (visited.has(set)) return acc
   visited.add(set)
   for (const f of set.fields) {

--- a/src/test/dictionary/trim-round-trip.test.ts
+++ b/src/test/dictionary/trim-round-trip.test.ts
@@ -43,7 +43,7 @@ function compareMessageFully (original: FixDefinitions, trimmed: FixDefinitions,
   const tTags = new Set(Object.keys(t.containedTag).map(Number))
   const missing = [...oTags].filter(tag => !tTags.has(tag))
   if (missing.length > 0) {
-    const lookup = (tag: number) => {
+    const lookup = (tag: number): string => {
       for (const sd of original.simple.values()) {
         if (sd.tag === tag) return sd.name
       }

--- a/src/test/session/issue-153-transport-subscription.test.ts
+++ b/src/test/session/issue-153-transport-subscription.test.ts
@@ -90,8 +90,8 @@ test('listeners do not accumulate on the transport across reconnects', async () 
   }
 
   // exactly one live subscription at any time
-  expect(transportListenerCount(last as MsgTransport)).toBeGreaterThan(0)
-  expect((last as MsgTransport).receiver.listenerCount('msg')).toBe(1)
+  expect(transportListenerCount(last!)).toBeGreaterThan(0)
+  expect((last!).receiver.listenerCount('msg')).toBe(1)
 })
 
 test('an end from a replaced transport does not terminate the live session', async () => {

--- a/src/test/session/session-sequence-coordinator.test.ts
+++ b/src/test/session/session-sequence-coordinator.test.ts
@@ -15,7 +15,11 @@ class TestClock implements IFixClock {
   }
 }
 
-function createCoordinator (store?: MemorySequenceStore, clock?: TestClock) {
+function createCoordinator (store?: MemorySequenceStore, clock?: TestClock): {
+  coordinator: SessionSequenceCoordinator
+  store: MemorySequenceStore
+  clock: TestClock
+} {
   const s = store ?? new MemorySequenceStore()
   const c = clock ?? new TestClock()
   return { coordinator: new SessionSequenceCoordinator(s, c), store: s, clock: c }

--- a/src/test/tcp/acceptor-transport-lifecycle.test.ts
+++ b/src/test/tcp/acceptor-transport-lifecycle.test.ts
@@ -74,13 +74,13 @@ async function listen (config: IJsFixConfig): Promise<IRunningAcceptor> {
     acceptor,
     port,
     transports,
-    close: async () => await new Promise<void>(resolve => { acceptor.close(() => resolve()) })
+    close: async () => { await new Promise<void>(resolve => { acceptor.close(() => { resolve() }) }) }
   }
 }
 
 async function connectClient (port: number): Promise<net.Socket> {
   return await new Promise<net.Socket>((resolve, reject) => {
-    const socket = net.connect(port, '127.0.0.1', () => resolve(socket))
+    const socket = net.connect(port, '127.0.0.1', () => { resolve(socket) })
     socket.on('error', reject)
   })
 }

--- a/src/test/tcp/issue-94-reject-unauthorized.test.ts
+++ b/src/test/tcp/issue-94-reject-unauthorized.test.ts
@@ -31,13 +31,13 @@ async function withSelfSignedTlsServer<T> (fn: (port: number) => Promise<T>): Pr
   const server = tls.createServer({ key: selfSignedKey, cert: selfSignedCert }, (socket) => {
     socket.end()
   })
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  await new Promise<void>((resolve) => { server.listen(0, '127.0.0.1', resolve) })
   const address = server.address()
   const port = typeof address === 'object' && address !== null ? address.port : 0
   try {
     return await fn(port)
   } finally {
-    await new Promise<void>((resolve) => server.close(() => resolve()))
+    await new Promise<void>((resolve) => { server.close(() => { resolve() }) })
   }
 }
 

--- a/src/test/tcp/tls-options-factory.test.ts
+++ b/src/test/tcp/tls-options-factory.test.ts
@@ -97,12 +97,12 @@ describe('tls diagnostics', () => {
 
   it('describes a live handshake and the peer certificate identity', async () => {
     const server = tls.createServer({ key: selfSignedKey, cert: selfSignedCert }, (s) => s.end())
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    await new Promise<void>((resolve) => { server.listen(0, '127.0.0.1', resolve) })
     const address = server.address()
     const port = typeof address === 'object' && address !== null ? address.port : 0
     try {
       const socket = await new Promise<tls.TLSSocket>((resolve, reject) => {
-        const s = tls.connect({ host: '127.0.0.1', port, rejectUnauthorized: false }, () => resolve(s))
+        const s = tls.connect({ host: '127.0.0.1', port, rejectUnauthorized: false }, () => { resolve(s) })
         s.on('error', reject)
       })
       const negotiated = describeNegotiated(socket)
@@ -117,7 +117,7 @@ describe('tls diagnostics', () => {
       expect(peer).not.toContain('BEGIN CERTIFICATE')
       socket.end()
     } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await new Promise<void>((resolve) => { server.close(() => { resolve() }) })
     }
   }, 20000)
 })

--- a/src/transport/session/fix-clock.ts
+++ b/src/transport/session/fix-clock.ts
@@ -1,5 +1,5 @@
 export interface IFixClock {
-  now (): Date
+  now: () => Date
 }
 
 export class DefaultFixClock implements IFixClock {

--- a/src/transport/session/resend-request-manager.ts
+++ b/src/transport/session/resend-request-manager.ts
@@ -46,7 +46,7 @@ export class ResendAction {
 }
 
 export class PendingResendRange {
-  private readonly receivedSeqs: Set<number> = new Set()
+  private readonly receivedSeqs = new Set<number>()
 
   constructor (
     public readonly begin: number,
@@ -190,11 +190,11 @@ export class ResendRequestManager {
     // keep requestHistory for debugging
   }
 
-  get pending (): ReadonlyArray<PendingResendRange> {
+  get pending (): readonly PendingResendRange[] {
     return this.pendingRequests.slice()
   }
 
-  get history (): ReadonlyArray<ResendRequestRecord> {
+  get history (): readonly ResendRequestRecord[] {
     return this.requestHistory.slice()
   }
 
@@ -240,7 +240,7 @@ export class ResendRequestManager {
       return { begin: gapBegin, end: gapEnd }
     }
 
-    const covered: Set<number> = new Set()
+    const covered = new Set<number>()
     for (const pending of this.pendingRequests) {
       for (let seq = pending.begin; seq <= pending.end; seq++) {
         covered.add(seq)

--- a/src/transport/session/session-sequence-coordinator.ts
+++ b/src/transport/session/session-sequence-coordinator.ts
@@ -160,7 +160,7 @@ export class SessionSequenceCoordinator {
     this.resendManager.recordRequestSent(begin, end, now)
   }
 
-  get pendingResendRequests (): ReadonlyArray<PendingResendRange> {
+  get pendingResendRequests (): readonly PendingResendRange[] {
     return this.resendManager.pending
   }
 

--- a/src/transport/session/session-sequence-store.ts
+++ b/src/transport/session/session-sequence-store.ts
@@ -6,9 +6,9 @@
 export interface ISessionSequenceStore {
   senderSeqNum: number
   targetSeqNum: number
-  setSenderSeqNum (value: number): Promise<void>
-  setTargetSeqNum (value: number): Promise<void>
-  reset (): Promise<void>
+  setSenderSeqNum: (value: number) => Promise<void>
+  setTargetSeqNum: (value: number) => Promise<void>
+  reset: () => Promise<void>
 }
 
 /**

--- a/src/transport/tcp/tcp-initiator.ts
+++ b/src/transport/tcp/tcp-initiator.ts
@@ -198,7 +198,7 @@ export class TcpInitiator extends FixInitiator {
       const timeoutPromise = promisify(setTimeout)
       const reconnectSeconds = application?.reconnectSeconds ?? 5
       let retries = 0
-      let lastError: Error = initialError as Error
+      let lastError: Error | undefined = initialError
       const name = application?.name ?? 'initiator'
       this.th = setInterval(() => {
         ++retries


### PR DESCRIPTION
npx eslint . reported 93 problems. This clears all of them.

Autofixable style rules were applied as-is: no-multi-spaces, no-confusing-void-expression, consistent-generic-constructors, dot-notation, array-type, method-signature-style and non-nullable-type-assertion-style. method-signature-style rewrites IFixClock and ISessionSequenceStore to property syntax, which is a declaration change only.

The non-null assertions in src proper are gone for real:

 - ascii-segment-parser carries the message definition on a const the compiler already sees as non-optional, since the null guard does not narrow inside the hoisted helpers.
 - quick-fix-graph-parser drains its work queue from shift() directly.
 - file-session-stream-provider grew a private openBodyFd() that opens on first use and hands back the descriptor.
 - tcp-initiator types lastError as Error | undefined, which is what it always was - the old `initialError as Error` and the autofixed `!` were both wrong.

Two rules are switched off rather than worked around:

 - prefer-named-capture-group cannot be satisfied while tsconfig targets es6, named groups need es2018.
 - no-non-null-assertion and require-atomic-updates are off under src/test. Tests assert presence with expect(x).toBeDefined() and then use x!, and the lingerMs save/restore is not a race in a serially run jest file. Both stay enforced in src proper.

coverage/ is now ignored - it was reporting unused eslint-disable directives against generated istanbul output.

tsc --noEmit is clean and all 595 tests in 56 suites pass.