### PR TITLE
Worklog for 5.10.0, and a plan for a FIXatdl renderer

### DIFF
--- a/ATDL_PLAN.md
+++ b/ATDL_PLAN.md
@@ -1,0 +1,109 @@
+# FIXatdl renderer and end-to-end test harness
+
+Design notes from 2026-08-08. Nothing is built yet. This exists so the next session
+can start from the thinking rather than redo it.
+
+**First decision to settle:** this is not jspurefix work and should almost certainly
+live in its own repository (`jspf-atdl`, or similar). The plan is parked here because
+it is where the conversation happened and because the back-end half does use the
+engine. Move it when the code starts.
+
+---
+
+## The problem
+
+A broker publishes a FIXatdl document per algorithm: an XML definition of its
+parameters and the order ticket used to fill them in. An EMS — Bloomberg EMSX,
+Flextrade, Portware, Fidessa, ITG Triton — renders the ticket from that document, and
+the values map onto FIX tags, usually the `NoStrategyParameters` group.
+
+The observed pain, in more than one shop: getting a definition rendered is cobbled
+together, and **you cannot tell whether a definition is sound until a vendor renders
+it**. The loop is write it, send it, wait, discover it renders differently in EMSX
+than in Triton, repeat. Nothing good and open exists to shorten that.
+
+The goal is to close the loop locally, and then go one step further than any renderer
+does — send the resulting order to a back end that answers, so a definition can be
+proved end to end before it goes to clients.
+
+## What it actually is
+
+**An interpreter, not an application.** The UI is entirely data driven: you never
+hand-write a component per algorithm, you walk the layout tree. That single
+observation drives every technology choice below.
+
+The state is a flat map of control id to value. There is no routing, no server state,
+no virtualised list, no async rendering. Almost nothing a UI framework is good at is
+in play.
+
+## Technology
+
+Deliberately small. FIXatdl is *already* a declarative UI description — wrapping it in
+React means writing a compiler from one declarative tree into another and inheriting a
+second lifecycle model, build chain and version churn, for a form with thirty
+controls.
+
+- **`DOMParser` for the XML.** ATDL is split across several namespaces — core,
+  layout, validation, flow control — and `getElementsByTagNameNS` is exactly the tool
+  for that. Built into every browser, zero dependencies.
+- **Plain DOM for rendering.** Walk the layout tree, emit a label and an input per
+  control. On any change, re-evaluate every state rule and edit, then toggle
+  `disabled` / `hidden`. Tens of rules, not thousands — a full re-evaluation is
+  microseconds, so the machinery that exists to avoid one is dead weight.
+- **TypeScript for the model and interpreter**, built to a single ESM module. A build
+  step for the author, not for anyone using it.
+- **Static hosting, dynamic page.** One HTML file plus one module, opening from
+  `file://` if need be. Drag an ATDL file on, see it render, edit the XML, drop it
+  again.
+
+Note the distinction that matters: static **hosting**, not static **generation**.
+Generating HTML at build time would need a rebuild per edit, and the tight edit loop
+is the entire product.
+
+## Build order
+
+**The expression engine first, headless, with tests.** `StateRule` and `StrategyEdit`
+form a small expression language — operators, logical combinators, references to other
+controls — and that is where the time will go and where correctness actually matters.
+Unit-test it against real broker ATDL documents before drawing a single widget. If
+that engine is right the tool is good; if it is approximate, it is one more
+cobbled-together thing.
+
+Controls are the easy half and should come second.
+
+## Pluggable skins
+
+Part of the value is answering "roughly how will EMSX lay this out, versus Fidessa" —
+the question people genuinely cannot answer today. Keep layout strategy and CSS behind
+an adapter so the same definition can render two ways side by side. CSS custom
+properties cover it; still no framework.
+
+## The back end
+
+A browser cannot open a TCP FIX session, so:
+
+```
+page  --(WebSocket, composed order as JSON)-->  bridge  --(FIX)-->  test acceptor
+      <--(ExecutionReports)---------------------
+```
+
+The bridge owns a jspurefix initiator; the acceptor validates the strategy parameters
+against the same ATDL definition and answers. This keeps the page genuinely static and
+the FIX where it belongs.
+
+A thin WebSocket server is the right shape here — the engine's existing HTTP acceptor
+is FIXML-shaped and is not a good fit for this.
+
+## Rough size
+
+~1,500 lines of interpreter, zero runtime dependencies.
+
+## Open questions for next session
+
+1. Own repository or a folder here? (Recommendation: own repository.)
+2. Which real ATDL documents can be used as test fixtures? The expression engine is
+   only as good as what it is tested against, and broker-published files vary a lot.
+3. Which FIXatdl version to target. 1.1 is the one in widespread use; confirm before
+   writing the parser rather than after.
+4. How strategy parameters map onto the outbound order — the `NoStrategyParameters`
+   group versus direct custom tags — likely needs to be configurable per broker.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -2,7 +2,8 @@
 
 Running notes on what has been done and what is worth doing next, so a session can
 be resumed cold. The long-form plans live in `BACKPORT_PLAN.md` (engine, cspurefix →
-jspurefix) and `DEMO_PORT_PLAN.md` (the jspf-demo reference app).
+jspurefix), `DEMO_PORT_PLAN.md` (the jspf-demo reference app) and `ATDL_PLAN.md` (a
+FIXatdl renderer and test harness — a prospective sibling project, not engine work).
 
 ---
 
@@ -37,6 +38,62 @@ confirmation — see below).
 
 ---
 
+## 2026-08-08 — customising the Logon, and making silent drops visible, released as 5.10.0
+
+Started from [#93](https://github.com/TimelordUK/jspurefix/issues/93), open since
+December 2024, and ended up somewhere broader. Two issues that look unrelated turned
+out to share a theme: **the engine failed quietly in several places, and nobody could
+see it.**
+
+**Merged (PR #164):**
+
+- a `Logon` block in the session description, merged over the fields the engine
+  derives. `AsciiSessionMsgFactory.logon()` had read exactly five values off the
+  description and ignored everything else, so an `"Account"` in the config was never
+  looked at. A null in the block suppresses a field.
+- `AsciiEncoder` now reports a key it cannot resolve, via
+  `MsgEncoder.onUnknownField`. This was the real cause of the confusion: `Account` is
+  tag 1 but is not a field of FIX 4.4 `Logon`, so it was discarded with no error and
+  no log line. Only runs on the miss path — a key that resolves costs nothing.
+- `SessionContainer(provider)` and `SessionLauncher.makeSessionMsgFactory()`, so
+  supplying a factory no longer needs a `SessionContainer` subclass
+- `AsciiSessionMsgFactory` / `FixmlSessionMsgFactory` exported from the package root.
+  Extending the ascii factory — the thing every previous answer to these issues told
+  people to do — used to require importing through `dist/transport/ascii/...`.
+- an optional callback on `send`, giving back the stamped `StandardHeader` (and so
+  the sequence number) or an error. Writing it exposed three drops that told nobody:
+  `encodeMessage` returning null for an unknown msgType, a session in state
+  `Stopped`, and no transport at all. All three still reach the error channel; the
+  callback is additive.
+
+**Issues resolved:** #93, #86, #39, #96 (all commented with the full explanation).
+#69 verified fixed — `SenderSubID` has been in the header since `dd9a540` — and left
+open pending the reporter, since their actual complaint was "no response from the
+server".
+
+**Docs:** `docs/custom-logon.md`, plus README sections on the `Logon` block and on
+send callbacks.
+
+**Perf:** flat. Parse benchmarks moved inside the noise floor; Logon encode 2.26
+µs/msg against the 2.3 in the README table. The encoder change is genuinely off the
+hot path.
+
+**Demos:** `jspf-demo` gained a `custom-logon` mode (config block + generated
+dictionary + run-time factory, and one field deliberately left undeclared so the new
+warning is visible). `jspf-md-demo`'s `Msg44Fact` had a `logon()` that was a verbatim
+copy of the stock one — it showed the hook and never the point — and now sends a real
+bespoke tag; its generated types were regenerated in a separate commit, having
+drifted a long way behind the generator.
+
+**Found along the way:** jspf-demo had been sending every `TradeCaptureReportRequest`
+without its dates for as long as the demo has existed. `TrdCapDtGrp` was built as a
+flat array, which is how the FIX repository models it, but those sessions load the
+QuickFIX dictionary where it is a component wrapping `NoDates`. The encoder dropped
+it silently. The new warning is what caught it, about an hour after it existed — a
+fair advertisement for the feature.
+
+---
+
 ## Next up
 
 ### 1. Toolchain major bumps
@@ -49,10 +106,9 @@ acceptor work:
 - `eslint-config-love` 151 → 154
 - `@types/node` 25 → 26
 
-Expect lint churn. There are 17 pre-existing lint errors on master (`fix-clock`,
-`resend-request-manager`, `session-sequence-*`, `tcp-initiator`) — worth clearing in
-the same pass, since they make it hard to tell new problems from old. `npm audit` is
-currently clean.
+Expect lint churn. The 17 pre-existing lint errors noted here were cleared in
+`1d2f267` — `npx eslint src/` is clean on master as of 5.10.0, so any churn from the
+bump is genuinely new and worth reading. `npm audit` is clean.
 
 ### 2. #77 — confirm or close
 
@@ -76,14 +132,21 @@ reproduced.
 
 ### 3. Other open issues worth a look
 
-Several are old and may already be fixed, in the way #140 turned out to be — worth
-verifying against 5.9.1 rather than reading the thread:
+Most of this list was cleared in 5.10.0. What remains:
 
-- #96 / #69 — `DefaultApplVerID` / `SenderSubID` missing during login
-- #93 — customising the Logon message
-- #86 — make `encoderStream` protected
-- #85 — `ASessionMsgFactory` types patch (may be superseded by `cloneFor`)
-- #72 — `session-launcher.run()` never resolves when connection established
+- **#69** — verified fixed and commented; awaiting the reporter before closing. Their
+  literal question (`SenderSubID`) works; their real complaint was silence from
+  cServer, which is a different problem.
+- **#85** — `ASessionMsgFactory` types patch. Possibly superseded twice over now, by
+  `cloneFor` and by the root exports added in 5.10.0. Worth reading the patch against
+  current master before doing anything.
+- **#72** — `session-launcher.run()` never resolves when the connection is
+  established. Not looked at. Given how #140 and #77 went, verify against 5.10.0
+  before trusting the thread.
+
+The lesson from this batch, worth repeating: **several of these were already fixed,
+or were one line plus a docs gap.** Reading the thread is a poor substitute for
+running the reporter's config.
 
 ### 4. Small things noticed, none urgent
 


### PR DESCRIPTION
Docs only.

**`WORKLOG.md`** — a section for the 5.10.0 work, and a rewritten "Next up". The old
one listed #93, #86, #96 and #69 as worth verifying; all are now resolved, so the
section is replaced rather than appended to. Also corrects the note claiming 17
pre-existing lint errors — they were cleared in `1d2f267` and `npx eslint src/` is
clean on master.

What remains open and is honestly described as such: #69 (fixed, awaiting the
reporter), #85 (possibly superseded twice over), #72 (not looked at).

The lesson from this batch is recorded because it will apply again — several of these
issues were already fixed, or were one line plus a docs gap, and reading the thread
was a poor substitute for running the reporter's config.

**`ATDL_PLAN.md`** — design notes for a FIXatdl renderer and end-to-end test harness,
written down while the thinking is fresh. Nothing is built.

The short version: it is an interpreter rather than an application, so `DOMParser`
plus plain DOM plus TypeScript, no framework — FIXatdl is already a declarative UI
description and wrapping it in a second one buys nothing. Static hosting, dynamic
page. Expression engine (`StateRule`, `StrategyEdit`) built headless and tested first,
because that is where correctness actually lives. Back end is a jspurefix acceptor
behind a thin WebSocket bridge, since a browser cannot open a TCP FIX session.

The file states plainly that this is a prospective sibling project rather than engine
work, and that it should move to its own repository when code starts. It is parked
here because the back-end half is jspurefix and because this is where the conversation
happened — happy to move it now instead if you would rather keep the engine repo to
engine matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)