### PR TITLE
fix: give an application a way to close its acceptor's listener

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -6,6 +6,38 @@ jspurefix) and `DEMO_PORT_PLAN.md` (the jspf-demo reference app).
 
 ---
 
+## 2026-08-08 — closing the acceptor's listener
+
+Reported from jspf-demo: `npm run custom-logon` never exits. The logs say everything
+shut down — sessions logged out, transports harvested, registry empty, `.. done` —
+and the node process sits there.
+
+Diagnosed by dumping `process._getActiveHandles()` after the run. Session and
+transport teardown is complete; the only handle left is the listening `net.Server`.
+A listening socket keeps node alive by itself, and nothing ever closed it.
+
+`TcpAcceptorListener.stop()` has always existed and does the right thing. What was
+missing was any way to *call* it: `SessionLauncher.stopAcceptor()` was private and
+reached only from the branch where one launcher holds both roles. An application that
+gives its acceptor a launcher of its own — which jspf-demo started doing on 2026-08-01
+so the acceptor would survive any one client — could not close its listener at all.
+
+**Changed:** `SessionLauncher.stop()`, public. Remembers a stop that arrives before
+the acceptor has started (`makeSystem` is async, so that window is real) and never
+opens the listener in that case. `run()` resolves once the listener has closed.
+Pinned by `src/test/session/launcher-stop.test.ts`.
+
+Worth checking against
+[#72](https://github.com/TimelordUK/jspurefix/issues/72) ("`session-launcher.run()`
+never resolves when connection established") before that issue is next looked at —
+for an acceptor, run() not resolving was the designed behaviour with no way out, and
+now there is one.
+
+`docs/acceptor.md` gained a "Closing the listener" section, because from the outside
+this reads as a hang rather than as a decision.
+
+---
+
 ## 2026-08-01 — acceptor hardening, released as 5.9.1
 
 Started from [#153](https://github.com/TimelordUK/jspurefix/issues/153) and ended up

--- a/docs/acceptor.md
+++ b/docs/acceptor.md
@@ -199,6 +199,38 @@ asks for a resend, the stored bodies are replayed with `PossDupFlag=Y`.
 Because the store is keyed on `SessionId`, a wildcard acceptor recovers each
 counterparty independently.
 
+## Closing the listener
+
+An acceptor outlives its counterparties. A session ending closes nothing: the
+listener stays up, waiting for the next connection, which is the whole point of a
+venue and why `TcpAcceptorListener` never stops itself.
+
+The consequence is worth stating plainly, because it does not look like a decision
+from the outside — **a listening socket keeps node alive on its own**. Every session
+can log out, every transport can be harvested, the census can read `transports=0
+sessions=0`, and the process still will not exit. Nothing is stuck; there is simply
+one handle left, and only the application knows when it no longer wants it.
+
+`SessionLauncher.stop()` closes it:
+
+```ts
+const venue = new MyLauncher(null, acceptorDescription)
+const run = venue.run()          // resolves when the listener closes, not before
+
+process.once('SIGINT', () => { venue.stop() })
+await run                        // ... and now the process can end
+```
+
+`stop()` releases any live transports rather than waiting on them — `net.Server.close`
+alone would block on whichever counterparty happened to be connected, and forever on
+a half-open one. It is safe before the listener has opened (the request is remembered
+and it never opens) and safe to call twice.
+
+A launcher given *both* roles calls this for you when its client finishes, which is
+why a single-launcher sample exits by itself. An application that gives its acceptor a
+launcher of its own — the usual arrangement once more than one client is involved —
+owns that decision, and must say when.
+
 ## See also
 
 - [`src/transport/tcp/tcp-acceptor.ts`](../src/transport/tcp/tcp-acceptor.ts) — listener, transport lifecycle

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -57,11 +57,18 @@ export abstract class SessionLauncher {
   }
 
   private acceptorEntity: FixEntity | null = null
+  private stopRequested: boolean = false
 
   protected async getAcceptor (sessionContainer: DependencyContainer): Promise<any> {
     if (sessionContainer.isRegistered<FixEntity>(DITokens.FixEntity)) {
       const entity = sessionContainer.resolve<FixEntity>(DITokens.FixEntity)
       this.acceptorEntity = entity
+      // a stop can arrive while the container is still being built - the listener has
+      // no existence yet to close, so honour the request by never opening it
+      if (this.stopRequested) {
+        this.logger.info('stop requested before the acceptor started - not listening')
+        return this.empty()
+      }
       return entity.start()
     } else {
       return this.empty()
@@ -85,6 +92,27 @@ export abstract class SessionLauncher {
    */
   protected makeFactory (config: IJsFixConfig): EngineFactory | null {
     return null
+  }
+
+  /**
+   * Stop what this launcher started - in practice, close the acceptor's listener.
+   *
+   * An acceptor is meant to outlive any one counterparty, so nothing closes its
+   * listener on its own.  That is right for a venue and wrong for an application
+   * which knows it is finished: the listening socket alone keeps node alive, long
+   * after every session has logged out and every transport has been harvested.
+   *
+   * Until now the only caller was the both-roles branch of setup() below, which an
+   * application cannot reach once it gives the acceptor a launcher of its own - the
+   * usual arrangement as soon as more than one client is involved.  There was then
+   * no way to shut a listener down short of killing the process.
+   *
+   * Safe before start (the request is remembered and the listener never opens), and
+   * safe to call twice.  run() resolves once the listener has closed.
+   */
+  public stop (): void {
+    this.stopRequested = true
+    this.stopAcceptor()
   }
 
   public async run (): Promise<boolean> {
@@ -188,7 +216,7 @@ export abstract class SessionLauncher {
       // stop the acceptor so the process can exit cleanly.
       await client
       this.logger.info('client finished, stopping acceptor')
-      this.stopAcceptor()
+      this.stop()
       return true
     }
     return await Promise.all([server, client])

--- a/src/test/session/launcher-stop.test.ts
+++ b/src/test/session/launcher-stop.test.ts
@@ -1,0 +1,157 @@
+import 'reflect-metadata'
+
+import * as net from 'net'
+import { SessionLauncher } from '../../runtime/session-launcher'
+import { EngineFactory } from '../../runtime/engine-factory'
+import { EmptyLogFactory, IJsFixConfig } from '../../config'
+import { AsciiSession, ISessionDescription } from '../../transport'
+import { MsgView } from '../../buffer'
+
+/**
+ * Closing an acceptor's listener.
+ *
+ * An acceptor keeps listening after a session ends, which is what a venue wants and
+ * why TcpAcceptorListener.stop() is not called on its own.  But nothing exposed that
+ * stop to the application: SessionLauncher only reached it from the branch where one
+ * launcher holds both roles, so an application which gives its acceptor a launcher of
+ * its own - the usual arrangement for more than one client - could not close the
+ * listener at all.  Every session would log out, every transport would be harvested,
+ * and the process would still sit there held open by the listening socket.
+ */
+
+/** logs on, does nothing, and schedules no timers of its own */
+class QuietSession extends AsciiSession {
+  constructor (config: IJsFixConfig) {
+    super(config)
+    this.heartbeat = false
+  }
+
+  protected onApplicationMsg (_msgType: string, _view: MsgView): void {}
+  protected onDecoded (_msgType: string, _txt: string): void {}
+  protected onEncoded (_msgType: string, _txt: string): void {}
+  protected onReady (_view: MsgView): void {}
+  protected onStopped (_error?: Error): void {}
+  protected onLogon (_view: MsgView, _user: string, _password: string): boolean {
+    return true
+  }
+}
+
+class AcceptorLauncher extends SessionLauncher {
+  constructor (description: ISessionDescription) {
+    // the probe connections below are deliberately rude - they connect and vanish
+    // without a Logon - so keep their (correct, and loud) session errors out of the
+    // test output
+    super(null, description, new EmptyLogFactory())
+  }
+
+  protected override makeFactory (_config: IJsFixConfig): EngineFactory {
+    return {
+      makeSession: (sessionConfig: IJsFixConfig) => new QuietSession(sessionConfig)
+    } as EngineFactory
+  }
+}
+
+function acceptorDescription (port: number): ISessionDescription {
+  return {
+    application: {
+      type: 'acceptor',
+      name: 'launcher_stop_test',
+      protocol: 'ascii',
+      dictionary: 'repo44',
+      tcp: { host: '127.0.0.1', port }
+    },
+    EncryptMethod: 0,
+    ResetSeqNumFlag: true,
+    HeartBtInt: 30,
+    SenderCompId: 'TEST_ACCEPTOR',
+    TargetCompID: 'TEST_CLIENT',
+    BeginString: 'FIX.4.4'
+  } as unknown as ISessionDescription
+}
+
+/** a free port, discovered by binding one and giving it straight back */
+async function freePort (): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const probe = net.createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address !== null ? address.port : 0
+      probe.close(() => { resolve(port) })
+    })
+  })
+}
+
+async function connects (port: number): Promise<boolean> {
+  return await new Promise<boolean>(resolve => {
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function delay (ms: number): Promise<void> {
+  await new Promise<void>(resolve => { setTimeout(resolve, ms) })
+}
+
+async function waitUntilListening (port: number, timeoutMs = 10000): Promise<void> {
+  const start = Date.now()
+  while (!(await connects(port))) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for a listener on ${port}`)
+    }
+    await delay(10)
+  }
+}
+
+describe('stopping an acceptor only launcher', () => {
+  test('the listener closes and run() resolves', async () => {
+    const port = await freePort()
+    const launcher = new AcceptorLauncher(acceptorDescription(port))
+
+    let finished = false
+    const run = launcher.run().then(() => { finished = true })
+    await waitUntilListening(port)
+
+    // the acceptor is doing exactly what it should: run() has not resolved, because a
+    // listener with no clients is still a listener
+    expect(finished).toBe(false)
+
+    launcher.stop()
+    await run
+
+    expect(finished).toBe(true)
+    expect(await connects(port)).toBe(false)
+  }, 30000)
+
+  test('a stop before the listener opens is honoured, not lost', async () => {
+    const port = await freePort()
+    const launcher = new AcceptorLauncher(acceptorDescription(port))
+
+    // makeSystem is async, so this lands while the container is still being built -
+    // the window in which the acceptor entity does not exist yet
+    const run = launcher.run()
+    launcher.stop()
+    await run
+
+    expect(await connects(port)).toBe(false)
+  }, 30000)
+
+  test('stop is idempotent', async () => {
+    const port = await freePort()
+    const launcher = new AcceptorLauncher(acceptorDescription(port))
+    const run = launcher.run()
+    await waitUntilListening(port)
+
+    launcher.stop()
+    launcher.stop()
+    await run
+
+    expect(await connects(port)).toBe(false)
+  }, 30000)
+})


### PR DESCRIPTION
Reported from jspf-demo: a run never exits.  The logs say everything shut down - sessions logged out, transports harvested, registry empty - and the node process sits there.

Dumping process._getActiveHandles() after the run shows session and transport teardown is complete.  The only handle left is the listening net.Server, and a listening socket keeps node alive by itself.

TcpAcceptorListener.stop() has always existed and does the right thing. What was missing was any way to call it: stopAcceptor() was private and reached only from the branch where one launcher holds both roles.  An application that gives its acceptor a launcher of its own - the usual arrangement once more than one client is involved - could not close its listener at all.

SessionLauncher.stop() is now public.  It remembers a stop that arrives before the acceptor has started, since makeSystem is async and that window is real, and never opens the listener in that case.  run() resolves once the listener has closed.

An acceptor still keeps listening on its own - that is right for a venue, and the decision of when it should not now belongs to the application.