### PR TITLE
ATDL plan: what the first public fixture does and does not prove

### DIFF
--- a/ATDL_PLAN.md
+++ b/ATDL_PLAN.md
@@ -1,12 +1,12 @@
 # FIXatdl renderer and end-to-end test harness
 
-Design notes from 2026-08-08. Nothing is built yet. This exists so the next session
-can start from the thinking rather than redo it.
+Design notes from 2026-08-08, fixtures added 2026-08-09. Nothing is built yet. This
+exists so the next session can start from the thinking rather than redo it.
 
-**First decision to settle:** this is not jspurefix work and should almost certainly
-live in its own repository (`jspf-atdl`, or similar). The plan is parked here because
-it is where the conversation happened and because the back-end half does use the
-engine. Move it when the code starts.
+**Where this lives:** staying in jspurefix for now (decided 2026-08-09). It is not
+engine work and will want its own repository once there is code, but the back-end half
+is a jspurefix acceptor and there is no benefit to a second repository holding only a
+markdown file.
 
 ---
 
@@ -15,7 +15,7 @@ engine. Move it when the code starts.
 A broker publishes a FIXatdl document per algorithm: an XML definition of its
 parameters and the order ticket used to fill them in. An EMS — Bloomberg EMSX,
 Flextrade, Portware, Fidessa, ITG Triton — renders the ticket from that document, and
-the values map onto FIX tags, usually the `NoStrategyParameters` group.
+the values map onto FIX tags.
 
 The observed pain, in more than one shop: getting a definition rendered is cobbled
 together, and **you cannot tell whether a definition is sound until a vendor renders
@@ -98,12 +98,80 @@ is FIXML-shaped and is not a good fit for this.
 
 ~1,500 lines of interpreter, zero runtime dependencies.
 
+## Fixtures
+
+The expression engine is only as good as what it is tested against, and this is the
+part most likely to be underestimated. Real broker documents vary enormously and most
+are proprietary — the user has worked at a bank where every algo was defined in ATDL,
+none of it publishable.
+
+### routefire/rf-fix-atdl
+
+`rf_strategies-v1.1.xml` — the first public fixture, 184 lines, 7 strategies (TWAP,
+VWAP, PVOL, ISO, FAST, ULMT, RLMT).
+
+What it settles:
+
+- **Version is 1.1.** Namespaces are `.../FIXatdl-1-1/Core`, `/Validation`, `/Layout`,
+  `/Flow`, `/Timezones`. Target 1.1 and stop worrying about it.
+- **Strategy identification is an attribute of `<Strategies>`:**
+  `strategyIdentifierTag="847"` and `versionIdentifierTag="7621"`, with each
+  `<Strategy>` carrying `wireValue`. So the algorithm is named on the wire in tag 847
+  and the parameters go elsewhere.
+- **Parameters carry their own `fixTag`** — `126`, `168`, and customs `8001`–`8004`
+  here. This resolves the earlier open question about `NoStrategyParameters`: the
+  mapping is *data driven per parameter*, not a per-broker configuration switch. Build
+  it from the `fixTag` attribute; treat the strategy-parameters group as a second
+  mode for documents that omit `fixTag`, not as the default.
+- Useful attributes in the wild: `use="required|optional"`, `minValue`/`maxValue`,
+  `localMktTz`, `initValue`, `initValueMode`, `increment`.
+
+**What it does not exercise, which matters more.** This file is a skeleton — good for
+proving the parser, nearly useless for proving the interpreter:
+
+| | |
+|---|---|
+| `StateRule` | **none at all** — zero occurrences |
+| Control types | only `Clock_t`, `SingleSpinner_t`, `TextField_t` |
+| Parameter types | only `Float_t`, `Int_t`, `UTCTimestamp_t` |
+| `EnumPair` | none — so no dropdowns, no radio groups, no checkboxes |
+| Validation | two `val:StrategyEdit`, each a single `val:Edit`, operator `GT` only |
+| `logicOperator` / `editRef` | none — no AND/OR, no reusable named edits |
+| `flow:` | namespace declared, never used |
+
+So it will not tell us whether the hard half is right. Enable/disable/visibility logic
+is entirely absent, and validation never gets beyond one field-to-field comparison.
+
+### What a representative fixture needs
+
+Worth building by hand from experience rather than waiting to find one. Aim to cover:
+
+- `StateRule` driving `enabled`, `visible` and value assignment, keyed off another
+  control's value
+- a `StateRule` chain — B depends on A, C depends on B — to prove evaluation order and
+  catch cycles
+- `DropDownList_t` and `RadioButtonList_t` with `EnumPair` (`wireValue` distinct from
+  `uiRep`, which is where renderers commonly go wrong)
+- `CheckBox_t` and its `checkedEnumRef` / `uncheckedEnumRef`
+- `val:Edit` with `logicOperator="AND"` / `"OR"` and nested edits
+- `val:Edit` comparing against a literal `value=` as well as `field2=`
+- a named `<val:Edit id="...">` referenced by `editRef`, since reuse is where scoping
+  bugs live
+- `use="required"` interacting with a control that a `StateRule` has disabled — what
+  should validation do then? Real documents disagree, and vendors disagree with each
+  other
+- a deliberately broken document, so the tool's error reporting is exercised too
+
 ## Open questions for next session
 
-1. Own repository or a folder here? (Recommendation: own repository.)
-2. Which real ATDL documents can be used as test fixtures? The expression engine is
-   only as good as what it is tested against, and broker-published files vary a lot.
-3. Which FIXatdl version to target. 1.1 is the one in widespread use; confirm before
-   writing the parser rather than after.
-4. How strategy parameters map onto the outbound order — the `NoStrategyParameters`
-   group versus direct custom tags — likely needs to be configurable per broker.
+1. ~~Own repository or a folder here?~~ Settled: stays here for now.
+2. ~~Which FIXatdl version?~~ Settled: 1.1.
+3. ~~How do parameters map onto the order?~~ Settled: per-parameter `fixTag`, with the
+   strategy-parameters group as a fallback mode.
+4. Can any further public documents be found, or is the hand-built fixture above the
+   realistic path? The user has significant algo trading experience and can produce
+   something representative — that is likely to be worth more than another public file
+   of the routefire kind.
+5. What does the harness do when a `StateRule` disables a `required` parameter? Decide
+   deliberately and document it, because it is the sort of thing that differs between
+   EMSs and is exactly what the tool exists to surface.


### PR DESCRIPTION
Docs only, follow-on to #165.

[routefire/rf-fix-atdl](https://github.com/routefire/rf-fix-atdl/blob/master/rf_strategies-v1.1.xml) — 184 lines, 7 strategies — settles three open questions:

- **Version is 1.1**, confirmed from the namespaces
- **The algorithm is named on the wire** via `strategyIdentifierTag="847"` on `<Strategies>` plus each strategy's `wireValue`, with `versionIdentifierTag="7621"`
- **Parameters carry their own `fixTag`** (`126`, `168`, customs `8001`–`8004`). So the mapping is data driven per parameter, not a per-broker configuration switch — which is simpler than assumed. `NoStrategyParameters` becomes a fallback for documents that omit `fixTag`, not the default.

The more useful finding is what it leaves out. It exercises the parser and almost none of the interpreter:

| | |
|---|---|
| `StateRule` | **none at all** |
| Control types | `Clock_t`, `SingleSpinner_t`, `TextField_t` only |
| `EnumPair` | none — no dropdowns, radios or checkboxes |
| Validation | two edits, operator `GT`, field-to-field only |
| `logicOperator` / `editRef` | none |
| `flow:` | declared, never used |

Since the hard half of this project is the expression engine, a fixture with zero state rules cannot tell us whether it is right. Recorded a checklist of what a representative document needs — state rule chains, `EnumPair` with `wireValue` distinct from `uiRep`, AND/OR and nested edits, named edits by `editRef`, and the awkward case of a `required` parameter that a state rule has disabled, which real EMSs handle differently and is exactly what the tool exists to surface.

Also settles the repo question: staying here for now, since a second repository holding one markdown file buys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)