### PR TITLE
security: clear audit findings and stop the recurrence (#91)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Keep routine dev-toolchain churn to a single PR rather than one per package.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,27 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Gate on what consumers actually inherit. Dev-only toolchain advisories are
+      # reported below but do not fail the build.
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Audit all dependencies (report only)
+        run: npm audit || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "align-text": "^1.0.2",
         "axios": "^1.19.0",
         "express": "^5.2.1",
         "lodash": "^4.18.1",
@@ -18,7 +17,6 @@
         "minimist": "^1.2.8",
         "minimist-options": "^4.1.0",
         "moment": "^2.30.1",
-        "node-fs-extra": "^0.8.2",
         "reflect-metadata": "^0.2.2",
         "sax": "^1.6.1",
         "tsyringe": "^4.10.0",
@@ -2970,19 +2968,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/align-text": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-1.0.2.tgz",
-      "integrity": "sha512-uBPDs72zrRTdiTBY0YjBbuBOdXtRyT4qsKPb4bL4O7vH4utz/7KjwTJVsVbdThxMbVzkRGAfk8Ml3xoMvXSEYw==",
-      "dependencies": {
-        "kind-of": "^5.0.2",
-        "longest": "^2.0.1",
-        "repeat-string": "^1.6.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -8070,11 +8055,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.1.1.tgz",
-      "integrity": "sha512-yrmo536TrJWDHNYlkCjtkPSqNnAkt6u1k89O5Xxr53zc4DkdikTHE+Fx6VF7syJd18xsdo24U4csedAkhLgxVQ=="
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8098,14 +8078,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-      "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/kuler": {
@@ -8255,14 +8227,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/longest": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
-      "integrity": "sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/loose-envify": {
@@ -8530,12 +8494,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-      "integrity": "sha512-8OCq0De/h9ZxseqzCH8Kw/Filf5pF/vMI6+BH7Lu0jXz2pqYCjTAQRolSxRIi+Ax+oCCjlxoJMP0YQ4XlrQNHg==",
-      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)"
-    },
     "node_modules/module-definition": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.0.tgz",
@@ -8597,9 +8555,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -8637,14 +8595,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha512-PfGU8jYWdRl4FqJfCy0IzbkGyFHntfWygZg46nFk/dJD/XRrk2cj0SsKSX9n5u5gE0E0YfEpKWrEkfjnlZSTXA==",
-      "bin": {
-        "ncp": "bin/ncp"
-      }
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -8660,25 +8610,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-fs-extra": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/node-fs-extra/-/node-fs-extra-0.8.2.tgz",
-      "integrity": "sha512-C396wQ2aEpuUIlv9BwQvG8uaDhi2ro4hhv1muBb1nb1d7KWqgBRPn1F64PMVB6hElpbE74JY+67L00IkA9DDkQ==",
-      "dependencies": {
-        "jsonfile": "~1.1.0",
-        "mkdirp": "0.3.x",
-        "ncp": "~0.4.2",
-        "rimraf": "~2.2.0"
-      }
-    },
-    "node_modules/node-fs-extra/node_modules/rimraf": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-      "integrity": "sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==",
-      "bin": {
-        "rimraf": "bin.js"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -9731,14 +9662,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "align-text": "^1.0.2",
     "axios": "^1.19.0",
     "express": "^5.2.1",
     "lodash": "^4.18.1",
@@ -91,7 +90,6 @@
     "minimist": "^1.2.8",
     "minimist-options": "^4.1.0",
     "moment": "^2.30.1",
-    "node-fs-extra": "^0.8.2",
     "reflect-metadata": "^0.2.2",
     "sax": "^1.6.1",
     "tsyringe": "^4.10.0",

--- a/src/dictionary/compiler/standard-snippet.ts
+++ b/src/dictionary/compiler/standard-snippet.ts
@@ -6,8 +6,8 @@ export class StandardSnippet {
   }
 
   private static rhsJustify (txt: string, width: number): string {
-    const align = require('align-text')
-    return align(txt, width)
+    const pad = ' '.repeat(Math.max(0, width))
+    return txt.split(/\r\n|\n/).map(line => pad + line).join('\n')
   }
 
   // import { camelName } from './component/name_underscore'

--- a/src/jsfix-cmd.ts
+++ b/src/jsfix-cmd.ts
@@ -21,7 +21,7 @@ import { DITokens } from './runtime/di-tokens'
 import buildOptions from 'minimist-options'
 import { QuickFixXmlFileBuilder } from './dictionary/parser/quickfix/quick-fix-xml-file-builder'
 
-const fs = require('node-fs-extra')
+const fs = require('fs')
 
 const options = buildOptions({
   dict: {
@@ -439,7 +439,7 @@ export class JsfixCmd {
 
   async ensureExists (path: string): Promise<any> {
     return await new Promise<any>((resolve, reject) => {
-      fs.mkdirp(path, (err: Error) => {
+      fs.mkdir(path, { recursive: true }, (err: Error) => {
         if (err) {
           reject(err)
         } else {

--- a/src/runtime/session-container.ts
+++ b/src/runtime/session-container.ts
@@ -8,7 +8,6 @@ import {
   TcpAcceptorListener, RecoveringTcpInitiator,
   TcpInitiatorConnector, TcpInitiator
 } from '../transport/tcp'
-import { HttpInitiator, HttpAcceptorListener, HttpJsonSampleAdapter } from '../transport/http'
 import { ISessionMsgFactory, MsgTransmitter, ISessionDescription } from '../transport'
 import { AsciiMsgTransmitter } from '../transport/ascii/ascii-msg-transmitter'
 import { FixmlMsgTransmitter } from '../transport/fixml/fixml-msg-transmitter'
@@ -18,7 +17,15 @@ import { ElasticBuffer, MsgEncoder, MsgParser } from '../buffer'
 import { AsciiParser, AsciiParserState, AsciiSegmentParser } from '../buffer/ascii'
 import { FixmlEncoder, FiXmlParser } from '../buffer/fixml'
 import { FixEntity } from '../transport/fix-entity'
-import { IHttpAdapter } from '../transport/http/http-adapter'
+import type { IHttpAdapter } from '../transport/http/http-adapter'
+
+/**
+ * The http transport pulls in express.  Only a fixml session registers it, so resolve
+ * it on demand - an ascii application should neither load that tree nor inherit it.
+ */
+function httpTransport (): typeof import('../transport/http') {
+  return require('../transport/http')
+}
 
 /**
  * Supplies the session message factory for a description.  Return null to accept the
@@ -165,10 +172,11 @@ export class SessionContainer {
       useClass: FixmlEncoder
     })
     sessionContainer.registerInstance<ElasticBuffer>(DITokens.TransmitBuffer, new ElasticBuffer(sendSize))
-    sessionContainer.register<HttpAcceptorListener>(HttpAcceptorListener, {
+    const { HttpInitiator, HttpAcceptorListener, HttpJsonSampleAdapter } = httpTransport()
+    sessionContainer.register(HttpAcceptorListener, {
       useClass: HttpAcceptorListener
     })
-    sessionContainer.register<HttpInitiator>(HttpInitiator, {
+    sessionContainer.register(HttpInitiator, {
       useClass: HttpInitiator
     })
     if (this.isInitiator(description)) {

--- a/src/transport/duplex/http-duplex.ts
+++ b/src/transport/duplex/http-duplex.ts
@@ -1,7 +1,6 @@
 import { FixDuplex } from './fix-duplex'
 import { Readable, Writable } from 'stream'
-import axios from 'axios'
-import { IHttpAdapter } from '../http/http-adapter'
+import type { IHttpAdapter } from '../http/http-adapter'
 
 export class HttpDuplex extends FixDuplex {
   public constructor (public readonly adapter: IHttpAdapter) {
@@ -29,6 +28,9 @@ export class HttpDuplex extends FixDuplex {
           const adapter = this.adapter
           const options = adapter.getOptions(data)
           if (options) {
+            // resolved here rather than at module scope - this file is on the barrel
+            // export, and an ascii application should not load axios to reach it
+            const axios = require('axios').default
             axios(options).then((message: any) => {
               const body = adapter.endMessage(message)
               forward.push(body)


### PR DESCRIPTION
Closes #91.

## Where the issue actually stands

The ten vulnerabilities reported in #91 (Dec 2024) are **all already resolved** — they were cleared incidentally by dependency modernization since:

| Reported | Cleared by |
|---|---|
| `@babel/traverse` (critical) | jest 30 |
| `body-parser`, `cookie`, `path-to-regexp`, `send`, `serve-static` | express 4 → 5 |
| `braces`, `micromatch`, `cross-spawn` | toolchain updates |

One residual finding remained: `nanoid@3.3.16` ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), high), a **dev-only** transitive via `madge → dependency-tree → precinct → postcss`. Reachable only from `npm run circular`, and the loop needs a custom generator with size 0 — so no real exposure. Bumped to 3.3.18 as a lockfile-only change.

`npm audit` is now clean; `npm audit --omit=dev` was already clean.

## Why it sat open for 20 months

CI built and tested but never audited, and there was no dependabot config, so nothing was going to surface a new advisory. This PR adds both. The audit job fails only on **high/critical in the production tree** — what consumers actually inherit. Dev-toolchain advisories are reported but do not block a PR, so a transitive break in a build tool cannot wedge the pipeline.

## Shrinking the surface that caused this

`require('jspurefix')` was eagerly loading **express and axios** even for a plain ASCII session. `src/transport/index.ts` deliberately does not export `./http`, but `src/runtime/session-container.ts` imported `../transport/http` at module scope, and the duplex barrel re-exports `http-duplex`. So every consumer loaded the express tree — the source of five of the ten advisories here. Both are now resolved at their single point of use.

Also dropped two unmaintained production dependencies:

- **`node-fs-extra@0.8.2`** — used for `writeFile`, `readFile`, `mkdirp`; all available from `node:fs`, with `mkdir` recursive standing in for `mkdirp`.
- **`align-text@1.0.2`** — one call that left-pads each line by a fixed width. The replacement was diffed against the original package before removal.

Net: 861 → 822 installed packages.

## Verification

- 641 tests / 61 suites pass
- `npm ci` reproduces the tree; build clean
- `npm run circular` clean
- `npm audit --omit=dev --audit-level=high` exits 0
- Load probe confirms express and axios no longer load on import
- The `http-oms` sample completes a full FIXML logon → UserRequest → logout round trip over HTTP, which is the only thing exercising `HttpDuplex` (not covered by the test suite)

## Deliberately left for follow-up

- **express/axios are still in `dependencies`** — this PR stops them being *loaded*, not *installed*, so a downstream `npm audit` will still flag express CVEs. Moving them to `optionalDependencies`/`peerDependencies` is the durable fix, but it changes the install contract for HTTP transport users and wants its own release note.
- **`mathjs`** still loads eagerly for a single `format()` call in `elastic-buffer.ts:127`. That is the number-encoding hot path — a naive swap could change bytes on the wire, so it needs its own change with round-trip tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)