### PR TITLE
perf(buffer): retain grown buffer capacity across reset

### DIFF
--- a/src/buffer/elastic-buffer.ts
+++ b/src/buffer/elastic-buffer.ts
@@ -9,8 +9,18 @@ export class ElasticBuffer {
   private ptr: number = 0
   private stretched: number
 
+  /**
+   * A buffer grown to serve a large message keeps that capacity across reset, so a
+   * steady stream of similarly sized messages does not re-grow (and re-allocate) on
+   * every single message.  Only a buffer that has ballooned past returnTo is handed
+   * back, so one pathological message cannot pin a large allocation for the life of
+   * the session.  Unlike cspurefix - where the discarded array goes to a shared
+   * ArrayPool - the retained bytes are held by this instance, so an acceptor with
+   * many connections holds up to this much per connection.  Tune with
+   * DITokens.elasticBufferReturnSize.
+   */
   constructor (@inject(DITokens.elasticBufferSize) public readonly size: number = 6 * 1024,
-    @inject(DITokens.elasticBufferReturnSize) public readonly returnTo: number = 6 * 1024) {
+    @inject(DITokens.elasticBufferReturnSize) public readonly returnTo: number = 64 * 1024) {
     this.size = Math.max(1, this.size)
     this.buffer = Buffer.allocUnsafe(this.size)
     this.returnTo = Math.max(this.size, this.returnTo)
@@ -43,7 +53,7 @@ export class ElasticBuffer {
 
   public setPos (ptr: number): number {
     const r = this.ptr
-    if (ptr >= 0 && ptr <= this.size) {
+    if (ptr >= 0 && ptr <= this.buffer.length) {
       this.ptr = ptr
     }
     return r
@@ -134,7 +144,7 @@ export class ElasticBuffer {
     const shrink = this.stretched > this.returnTo
     if (shrink) {
       this.buffer = Buffer.allocUnsafe(this.returnTo)
-      this.stretched = this.size
+      this.stretched = this.returnTo
     }
     return shrink
   }

--- a/src/test/elastic-buffer.test.ts
+++ b/src/test/elastic-buffer.test.ts
@@ -213,14 +213,29 @@ test('write buffer', () => {
   expect(fetched).toEqual(b)
 })
 
-test('buffer shrinks', () => {
+test('buffer shrinks when grown past retain bound', () => {
+  // a buffer that balloons past returnTo is released on reset so a single
+  // pathological message cannot pin a large allocation for the session's life
   const buffer = new ElasticBuffer(1)
-  const s = '.'.repeat(60 * 1024)
+  const s = '.'.repeat(2 * buffer.returnTo)
   buffer.writeString(s)
   expect(buffer.getPos()).toEqual(s.length)
   expect(buffer.toString()).toEqual(s)
-  expect(buffer.currentSize()).toEqual(65536)
+  expect(buffer.currentSize() > buffer.returnTo).toBe(true)
   expect(buffer.reset()).toBe(true)
   expect(buffer.getPos()).toEqual(0)
-  expect(buffer.currentSize() < 60 * 1024).toBe(true)
+  expect(buffer.currentSize()).toEqual(buffer.returnTo)
+})
+
+test('buffer retains capacity within retain bound', () => {
+  // capacity below the bound is kept across reset - a steady stream of similarly
+  // sized messages must not re-grow (and re-allocate) on every single message
+  const buffer = new ElasticBuffer(1)
+  buffer.writeString('.'.repeat(8 * 1024))
+  const grown = buffer.currentSize()
+  expect(grown >= 8 * 1024).toBe(true)
+  expect(grown <= buffer.returnTo).toBe(true)
+  expect(buffer.reset()).toBe(false)
+  expect(buffer.getPos()).toEqual(0)
+  expect(buffer.currentSize()).toEqual(grown)
 })


### PR DESCRIPTION
Ports the `Reset` half of cspurefix [dd160023](https://github.com/TimelordUK/cspurefix/commit/dd160023) — the part that stops a buffer throwing away capacity it just grew into.

## The problem

`ElasticBuffer` defaulted `returnTo` to the same 6KB as its starting size, so a buffer that grew to serve a large message discarded that capacity on the next `reset()`. The transmit buffer is registered at 10KB (`session-container.ts:130`), which the existing `Math.max(size, returnTo)` clamp pins `returnTo` to, so a stream of messages over 10KB paid two allocations each:

1. `checkGrowBuffer` → `allocUnsafe(20K)` + 10K copy
2. `reset()` → `allocUnsafe(10K)`

Both are above Node's 4KB internal `Buffer` pool threshold, so both are real allocations, and the buffer ping-ponged between the two sizes for every single message.

## The change

`returnTo` now defaults to 64KB, continuing to act as the retain bound the clamp already made it.

| Buffer | Before | After |
|---|---|---|
| ParseBuffer (160K, `maxMessageLen` 160K) | never grew or shrank | **unchanged** |
| TransmitBuffer (10K) | re-grew and re-shrank per oversized message | retains to 64K |
| default `new ElasticBuffer()` (6K) | retained to 6K | retains to 64K |

A buffer that balloons past the bound is still released, so one pathological message cannot pin a large allocation for the life of the session. Still tunable via `DITokens.elasticBufferReturnSize`.

## What did not port, and why

- **Returning the outgoing array to an `ArrayPool` on grow** — no analogue. `checkGrowBuffer` drops the old `Buffer` for the GC, which is correct here.
- **Gating per-message `Stopwatch`/metrics** — `ascii-parser.ts` has no per-message timing to gate.

## Tradeoff

`ElasticBuffer` is not pooled here — instances are long lived, one per session scope — so retained bytes are held per instance rather than handed back to a shared pool. An acceptor holds up to the bound per connection that has actually sent an oversized message (64K rather than 10K worst case). That is the reason for a bound rather than removing the shrink outright, and why the knob stays exposed.

Retaining is safe on the transmit path: `AsciiEncoder.trim()` copies the buffer out before the bytes reach the socket, so nothing aliases it across a reset.

## Latent bugs fixed alongside

- `setPos` bounded against `size`, the *initial* capacity, so a seek past it silently no-opped once the buffer had grown.
- `reset()` recorded `stretched` as `size` after allocating `returnTo` bytes, so `currentSize()` under-reported until the next grow. Reporting only — the shrink predicate could not misfire, and `checkGrowBuffer` reads `buffer.length`.

## Tests

`buffer shrinks` asserted the old shrink-to-start policy and is replaced by two tests covering both sides of the bound, written against `buffer.returnTo` so they track the default if it is retuned. Full suite green locally: 61 suites, 642 tests. Lint clean.

## Noted, not addressed

`AsciiView.toBuffer()` (`ascii-view.ts:52`) returns a live `subarray` over the parse buffer and `replaceDelimiter` writes into it, mutating the parse buffer in place. Pre-existing and untouched by this change — the 160K parse buffer never shrank, so no accidental fresh-allocation protection was in play — but it is a real aliasing hazard worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
