### PR TITLE
test(session): cover SenderSubID on the outbound header (issue #69)

### DIFF
--- a/src/test/ascii/sender-sub-id-header.test.ts
+++ b/src/test/ascii/sender-sub-id-header.test.ts
@@ -1,0 +1,56 @@
+import 'reflect-metadata'
+import * as path from 'path'
+
+import { SessionContainer } from '../../runtime'
+import { DITokens } from '../../runtime/di-tokens'
+import { ISessionDescription, ISessionMsgFactory, MsgTransmitter } from '../../transport'
+import { IJsFixConfig } from '../../config'
+import { ElasticBuffer } from '../../buffer'
+import { MsgType } from '../../types'
+
+/**
+ * Regression cover for issue #69 — "Parameter SenderSubID missing during login".
+ *
+ * SenderSubID (tag 50) given in the session description was not stamped onto the
+ * outbound header, so a counterparty requiring it (cTrader/cServer) never saw it and
+ * the only workaround was to install a custom session message factory overriding
+ * header(). It is part of the base header since dd9a540 — pin that so the field
+ * cannot quietly fall out of AsciiSessionMsgFactory.header() again.
+ */
+const root = path.join(__dirname, '../../../data')
+
+async function encodeLogon (extra: Partial<ISessionDescription> = {}): Promise<string> {
+  const base = JSON.parse(JSON.stringify(require(path.join(root, 'session/test-initiator.json'))))
+  const description: ISessionDescription = { ...base, ...extra }
+  const fixContainer = new SessionContainer()
+  fixContainer.reset()
+  fixContainer.registerGlobal('error')
+  const container = await fixContainer.makeSystem(description)
+  const config = container.resolve<IJsFixConfig>(DITokens.IJsFixConfig)
+  config.delimiter = config.logDelimiter
+  const transmitter = container.resolve<MsgTransmitter>(DITokens.MsgTransmitter)
+  const txBuffer = container.resolve<ElasticBuffer>(DITokens.TransmitBuffer)
+  const factory = container.resolve<ISessionMsgFactory>(DITokens.ISessionMsgFactory)
+  transmitter.send(MsgType.Logon, factory.logon())
+  return txBuffer.toString()
+}
+
+describe('SenderSubID on the outbound header (issue #69)', () => {
+  test('tag 50 is written when the session description supplies SenderSubID', async () => {
+    const wire = await encodeLogon({ SenderSubID: 'QUOTE' })
+    expect(wire).toContain('|50=QUOTE|')
+  })
+
+  test('no custom session message factory is needed for it', async () => {
+    // the workaround in #69 was overriding header() in a bespoke ISessionMsgFactory;
+    // the stock factory is resolved here and must carry the field on its own
+    const wire = await encodeLogon({ SenderSubID: 'QUOTE' })
+    expect(wire).toContain('35=A')
+    expect(wire).toContain('|50=QUOTE|')
+  })
+
+  test('tag 50 is absent when SenderSubID is not configured', async () => {
+    const wire = await encodeLogon()
+    expect(wire).not.toContain('|50=')
+  })
+})


### PR DESCRIPTION
Relates to #69.

#69 reported that `SenderSubID` set in the session description never reached the wire, so cTrader/cServer — which requires tag 50 — never answered the logon. The workaround at the time was a bespoke `ISessionMsgFactory` overriding `header()`.

The field has been part of `AsciiSessionMsgFactory.header()` since dd9a540. This adds wire-level cover so it cannot quietly fall out again, verified on 5.10.5 with the reporter's config shape:

```
8=FIX.4.4|9=0000126|35=A|49=init-comp|56=accept-comp|34=1|50=QUOTE|57=fix|52=...|98=0|108=30|141=Y|553=js-client|554=pwd-client|10=018|
```

Three assertions: tag 50 present when configured, present via the *stock* factory with no override (the thing the reporter had to hand-roll), and absent when not configured.

Test only — no production code changes. `npx jest src/test/ascii` passes, 244 tests across 30 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)