### PR TITLE
feat(session): honour the onLogon verdict and allow it to be async (#19, #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A fast, fully native TypeScript [FIX protocol](https://www.fixtrading.org/) engi
 - [Quickstart](#quickstart)
 - [Session Configuration](#session-configuration)
   - [Customising the Logon](#customising-the-logon)
+  - [Accepting or refusing a logon](#accepting-or-refusing-a-logon)
   - [TLS](#tls)
   - [Body length padding](#body-length-padding)
 - [Persistence & Recovery](#persistence--recovery)
@@ -167,6 +168,29 @@ Most counterparties want a tag on the Logon the standard message does not carry.
 ```
 
 A field named here must also be declared on `Logon` in the dictionary the session loads, or the encoder has no tag to write it to and will say so in the log. For values computed at run time, or for a header a counterparty stamps differently, supply your own session message factory. See [docs/custom-logon.md](docs/custom-logon.md) for the whole picture.
+
+### Accepting or refusing a logon
+
+`onLogon` is where an acceptor decides who gets a session. Return `true` to let the handshake finish; return `false` and the peer is sent a `Logout` explaining why and then disconnected — `onReady` is never reached and no heartbeat starts. The application learns the outcome through `onStopped(error)`.
+
+```ts
+protected onLogon (view: MsgView, user: string, password: string): boolean {
+  return user === 'js-client' && password === this.expectedPassword
+}
+```
+
+Credentials usually have to be checked against something the engine cannot wait on synchronously — an http api, a database, a secrets store. Return a promise and the session waits for it:
+
+```ts
+protected async onLogon (view: MsgView, user: string, password: string): Promise<boolean> {
+  const account = await this.directory.lookup(user)
+  return account?.enabled === true && await account.verify(password)
+}
+```
+
+While that promise is pending the transport is paused and anything the peer sends is queued, then replayed in order once the verdict arrives — a counterparty that pipelines messages behind its Logon will not have them dropped or reordered. If the promise rejects, the logon is refused rather than allowed through, and the rejection message is carried to the peer.
+
+An initiator can use the same hook: there `onLogon` fires on the acceptor's logon response, so returning `false` refuses the counterparty that answered.
 
 ### TLS
 

--- a/src/test/session/logon-verdict.test.ts
+++ b/src/test/session/logon-verdict.test.ts
@@ -1,0 +1,312 @@
+import 'reflect-metadata'
+
+import { Setup } from '../env/setup'
+import { makeSessionScope } from '../../runtime/session-scope'
+import { MsgTransport } from '../../transport/factory'
+import { FixDuplex, StringDuplex, StringDuplexTraits } from '../../transport'
+import { AsciiSession } from '../../transport/ascii/ascii-session'
+import { SessionState } from '../../transport/session/session-state'
+import { IJsFixConfig } from '../../config'
+import { MsgView } from '../../buffer'
+import { MsgType } from '../../types'
+
+/**
+ * onLogon is the application's say over who gets a session.
+ *
+ * Two long standing issues meet at this one call site:
+ *
+ *   #19 the returned boolean was read, logged and thrown away - refusing a peer had
+ *       no effect at all, the handshake completed regardless
+ *   #64 the hook was synchronous, so credentials could not be checked against an
+ *       async source such as an http api or a database
+ *
+ * So the verdict is now honoured, and it may arrive as a promise.  While that promise
+ * is pending the transport is paused and anything the peer sends is queued, because a
+ * TCP segment can carry several messages and the parser emits them all in one
+ * synchronous burst - see https://github.com/TimelordUK/jspurefix/issues/19 and
+ * https://github.com/TimelordUK/jspurefix/issues/64
+ */
+
+let setup: Setup
+
+beforeAll(async () => {
+  setup = new Setup()
+  await setup.init()
+}, 45000)
+
+type Verdict = boolean | Promise<boolean>
+
+interface ISent {
+  msgType: string
+  txt: string
+}
+
+/**
+ * A session that answers logon attempts however the test tells it to, and records
+ * enough of what happened to assert on it.  heartbeat is off so a refused session
+ * does not leave a timer holding the event loop open.
+ */
+class VerdictSession extends AsciiSession {
+  public verdict: () => Verdict = () => true
+  public readyCount: number = 0
+  public stopped: boolean = false
+  public stopError: Error | null = null
+  public readonly sent: ISent[] = []
+  public readonly seenLogonAttempts: Array<{ user: string, password: string }> = []
+
+  constructor (config: IJsFixConfig) {
+    super(config)
+    this.heartbeat = false
+  }
+
+  protected onApplicationMsg (_msgType: string, _view: MsgView): void {}
+  protected onDecoded (_msgType: string, _txt: string): void {}
+
+  protected onEncoded (msgType: string, txt: string): void {
+    this.sent.push({ msgType, txt })
+  }
+
+  protected onReady (_view: MsgView): void {
+    this.readyCount++
+  }
+
+  protected onStopped (error?: Error): void {
+    this.stopped = true
+    this.stopError = error ?? null
+  }
+
+  protected onLogon (_view: MsgView, user: string, password: string): Verdict {
+    this.seenLogonAttempts.push({ user, password })
+    return this.verdict()
+  }
+
+  public sentTypes (): string[] {
+    return this.sent.map(s => s.msgType)
+  }
+}
+
+function loopBack (lhs: FixDuplex, rhs: FixDuplex): void {
+  lhs.writable.on('data', (data: Buffer) => {
+    rhs.readable.push(data)
+  })
+}
+
+interface IConnection {
+  client: VerdictSession
+  server: VerdictSession
+  runs: Promise<any>
+}
+
+function connect (id: number = 1): IConnection {
+  const clientConfig = makeSessionScope(setup.clientConfig, {})
+  const serverConfig = makeSessionScope(setup.serverConfig, {})
+
+  const clientDuplex = new StringDuplex('', StringDuplexTraits.None)
+  const serverDuplex = new StringDuplex('', StringDuplexTraits.None)
+  loopBack(clientDuplex, serverDuplex)
+  loopBack(serverDuplex, clientDuplex)
+
+  const client = new VerdictSession(clientConfig)
+  const server = new VerdictSession(serverConfig)
+
+  const runs = Promise.all([
+    server.run(new MsgTransport(id, serverConfig, serverDuplex)).catch((e: Error) => e),
+    client.run(new MsgTransport(id, clientConfig, clientDuplex)).catch((e: Error) => e)
+  ])
+  return { client, server, runs }
+}
+
+async function waitFor (predicate: () => boolean, what: string, timeoutMs = 5000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for ${what}`)
+    }
+    await new Promise<void>(resolve => { setTimeout(resolve, 5) })
+  }
+}
+
+function loggedOn (session: VerdictSession): boolean {
+  const state = session.getState()
+  return state === SessionState.InitiationLogonResponse ||
+    state === SessionState.InitiationLogonReceived ||
+    state === SessionState.ActiveNormalSession
+}
+
+/** a promise the test hands to the session and settles when it chooses */
+function deferred (): { promise: Promise<boolean>, settle: (v: boolean) => void, fail: (e: Error) => void } {
+  let settle: (v: boolean) => void = () => {}
+  let fail: (e: Error) => void = () => {}
+  const promise = new Promise<boolean>((resolve, reject) => {
+    settle = resolve
+    fail = reject
+  })
+  return { promise, settle, fail }
+}
+
+describe('a synchronous verdict', () => {
+  test('true logs the peer on, as it always has', async () => {
+    const c = connect()
+    await waitFor(() => loggedOn(c.server), 'server logon')
+    await waitFor(() => loggedOn(c.client), 'client logon')
+
+    expect(c.server.readyCount).toBe(1)
+    expect(c.client.readyCount).toBe(1)
+    expect(c.server.sentTypes()).toContain(MsgType.Logon)
+
+    // the credentials really did reach the application
+    expect(c.server.seenLogonAttempts.length).toBe(1)
+
+    c.client.done()
+    c.server.done()
+    await c.runs
+  })
+
+  test('false from an acceptor refuses the peer instead of being ignored', async () => {
+    const c = connect()
+    c.server.verdict = () => false
+
+    await waitFor(() => c.server.stopped, 'server stop')
+
+    // #19: the handshake must not complete
+    expect(c.server.readyCount).toBe(0)
+    expect(c.server.getState()).toBe(SessionState.Stopped)
+    expect(c.server.sentTypes()).not.toContain(MsgType.Logon)
+
+    // the peer is told why rather than watching the socket go quiet
+    expect(c.server.sentTypes()).toContain(MsgType.Logout)
+    const logout = c.server.sent.find(s => s.msgType === MsgType.Logout)
+    expect(logout?.txt).toContain('logon rejected by application')
+
+    // and the application learns the outcome
+    expect(c.server.stopError?.message).toContain('logon rejected by application')
+
+    c.client.requestStop('peer refused the logon - test teardown')
+    await c.runs
+  })
+
+  test('false from an initiator refuses the acceptor that answered', async () => {
+    const c = connect()
+    // the initiator's onLogon fires on the acceptor's logon response
+    c.client.verdict = () => false
+
+    await waitFor(() => c.client.stopped, 'client stop')
+
+    expect(c.client.readyCount).toBe(0)
+    expect(c.client.getState()).toBe(SessionState.Stopped)
+    expect(c.client.sentTypes()).toContain(MsgType.Logout)
+
+    c.server.requestStop('peer refused the logon response - test teardown')
+    await c.runs
+  })
+})
+
+describe('an asynchronous verdict', () => {
+  test('resolving true completes the handshake once it arrives', async () => {
+    const gate = deferred()
+    const c = connect()
+    c.server.verdict = async () => await gate.promise
+
+    // the acceptor has read the logon and is waiting on the application
+    await waitFor(() => c.server.seenLogonAttempts.length === 1, 'onLogon call')
+    expect(c.server.readyCount).toBe(0)
+    expect(c.server.sentTypes()).not.toContain(MsgType.Logon)
+
+    gate.settle(true)
+
+    await waitFor(() => loggedOn(c.server), 'server logon')
+    await waitFor(() => loggedOn(c.client), 'client logon')
+    expect(c.server.readyCount).toBe(1)
+    expect(c.server.sentTypes()).toContain(MsgType.Logon)
+
+    c.client.done()
+    c.server.done()
+    await c.runs
+  })
+
+  test('resolving false refuses the peer', async () => {
+    const gate = deferred()
+    const c = connect()
+    c.server.verdict = async () => await gate.promise
+
+    await waitFor(() => c.server.seenLogonAttempts.length === 1, 'onLogon call')
+    expect(c.server.stopped).toBe(false)
+
+    gate.settle(false)
+
+    await waitFor(() => c.server.stopped, 'server stop')
+    expect(c.server.readyCount).toBe(0)
+    expect(c.server.sentTypes()).not.toContain(MsgType.Logon)
+    expect(c.server.sentTypes()).toContain(MsgType.Logout)
+
+    c.client.requestStop('peer refused the logon - test teardown')
+    await c.runs
+  })
+
+  test('a rejected promise refuses the peer rather than letting it in', async () => {
+    const gate = deferred()
+    const c = connect()
+    c.server.verdict = async () => await gate.promise
+
+    await waitFor(() => c.server.seenLogonAttempts.length === 1, 'onLogon call')
+    gate.fail(new Error('auth service unreachable'))
+
+    await waitFor(() => c.server.stopped, 'server stop')
+    expect(c.server.readyCount).toBe(0)
+    expect(c.server.sentTypes()).not.toContain(MsgType.Logon)
+    expect(c.server.stopError?.message).toContain('auth service unreachable')
+
+    c.client.requestStop('logon check failed - test teardown')
+    await c.runs
+  })
+})
+
+test('messages riding in behind the logon are held and replayed in order', async () => {
+  // Build the peer's traffic by hand so all of it lands in one push - this is the
+  // case the queue exists for: one TCP segment holding Logon, TestRequest,
+  // TestRequest, which the parser turns into three onMsg calls in a single
+  // synchronous burst while the application is still deciding.
+  const clientConfig = makeSessionScope(setup.clientConfig, {})
+  const serverConfig = makeSessionScope(setup.serverConfig, {})
+
+  const wire: Buffer[] = []
+  const clientDuplex = new StringDuplex('', StringDuplexTraits.None)
+  clientDuplex.writable.on('data', (data: Buffer) => {
+    wire.push(Buffer.from(data))
+  })
+  const clientTransport = new MsgTransport(1, clientConfig, clientDuplex)
+  const factory = clientConfig.factory
+  expect(factory).toBeTruthy()
+  if (!factory) return
+
+  clientTransport.transmitter.send(MsgType.Logon, factory.logon())
+  clientTransport.transmitter.send(MsgType.TestRequest, factory.testRequest('first'))
+  clientTransport.transmitter.send(MsgType.TestRequest, factory.testRequest('second'))
+  expect(wire.length).toBe(3)
+
+  const gate = deferred()
+  const serverDuplex = new StringDuplex('', StringDuplexTraits.None)
+  const server = new VerdictSession(serverConfig)
+  server.verdict = async () => await gate.promise
+  const runs = server.run(new MsgTransport(1, serverConfig, serverDuplex)).catch((e: Error) => e)
+
+  await waitFor(() => server.getState() === SessionState.WaitingForALogon, 'acceptor listening')
+  serverDuplex.readable.push(Buffer.concat(wire))
+
+  await waitFor(() => server.seenLogonAttempts.length === 1, 'onLogon call')
+  // nothing may be acted on while the verdict is outstanding - no logon response,
+  // and crucially no heartbeat answering a test request that arrived behind it
+  expect(server.sent.length).toBe(0)
+
+  gate.settle(true)
+  await waitFor(() => server.sent.length >= 3, 'replayed traffic')
+
+  // the logon response first, then the held test requests answered in the order
+  // the peer sent them
+  expect(server.sentTypes()).toEqual([MsgType.Logon, MsgType.Heartbeat, MsgType.Heartbeat])
+  expect(server.sent[1].txt).toContain('first')
+  expect(server.sent[2].txt).toContain('second')
+
+  server.requestStop('test teardown')
+  await runs
+}, 20000)

--- a/src/transport/ascii/ascii-session-msg-factory.ts
+++ b/src/transport/ascii/ascii-session-msg-factory.ts
@@ -33,11 +33,17 @@ export class AsciiSessionMsgFactory extends ASessionMsgFactory {
     return this.mutate(o, MsgType.Logon)
   }
 
-  public logout (text: string): ILooseObject {
+  /**
+   * ISessionMsgFactory declares logout (msgType, text) and FixSession calls it that
+   * way.  This override used to take the text alone, so it silently bound the msg
+   * type to Text and every Logout jspurefix sent carried '58=5' in place of the
+   * reason - the caller's message was dropped on the floor.
+   */
+  public logout (msgType: string, text: string): ILooseObject {
     const o: ILogout = {
       Text: text
     } as ILogout
-    return this.mutate(o, MsgType.Logout)
+    return this.mutate(o, msgType ?? MsgType.Logout)
   }
 
   public header (msgType: string, seqNum: number, time: Date, overrideData?: Partial<IStandardHeader>): ILooseObject {

--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -37,6 +37,7 @@ export abstract class AsciiSession extends FixSession {
   protected readonly wildcardTarget: boolean
   private identityBound: boolean
   private bindInProgress: boolean = false
+  private logonVerdictPending: boolean = false
   private readonly pendingRx: Array<{ msgType: string, view: MsgView }> = []
   private readonly clock: DefaultFixClock = new DefaultFixClock()
 
@@ -548,6 +549,13 @@ export abstract class AsciiSession extends FixSession {
       this.onMsgBeforeIdentity(msgType, view)
       return
     }
+    if (this.logonVerdictPending) {
+      // the application is still deciding whether to accept this peer - hold anything
+      // it sends in the meantime rather than acting on it (see awaitLogonVerdict)
+      this.sessionLogger.info(`queueing '${msgType}' received while awaiting logon verdict`)
+      this.pendingRx.push({ msgType, view: view.clone() })
+      return
+    }
     this.dispatchMsg(msgType, view)
   }
 
@@ -587,9 +595,11 @@ export abstract class AsciiSession extends FixSession {
     this.bindIdentity(peerCompId).then(() => {
       this.bindInProgress = false
       this.identityBound = true
+      // dispatching the logon can itself open a second gate - an application whose
+      // onLogon returns a promise is now deciding - so let resumeRx work out whether
+      // it is actually safe to let the socket run again
       this.dispatchMsg(MsgType.Logon, logon)
-      this.drainPendingRx()
-      this.transport?.duplex.readable?.resume()
+      this.resumeRx()
     }).catch((e: Error) => {
       this.bindInProgress = false
       this.pendingRx.length = 0
@@ -597,8 +607,34 @@ export abstract class AsciiSession extends FixSession {
     })
   }
 
+  /**
+   * True while an asynchronous step in the logon handshake is still running and no
+   * received message may be acted on: either the identity bind of a wildcard acceptor
+   * or an application still deciding the logon verdict.
+   */
+  private rxGated (): boolean {
+    return this.bindInProgress || this.logonVerdictPending
+  }
+
+  /**
+   * Let the socket run again now a gate has opened - but only if no other gate is
+   * still shut.  Draining can re-gate (a replayed message could start another async
+   * step) so the check is repeated after the queue is played out; whichever gate
+   * closes last is the one that resumes.
+   */
+  private resumeRx (): void {
+    if (this.rxGated()) return
+    this.drainPendingRx()
+    if (this.rxGated()) return
+    this.transport?.duplex.readable?.resume()
+  }
+
   private drainPendingRx (): void {
     while (this.pendingRx.length > 0) {
+      if (this.rxGated()) {
+        this.sessionLogger.info('suspending replay - logon handshake gated again')
+        return
+      }
       const queued = this.pendingRx.shift()
       if (!queued) break
       if (this.sessionState.state === SessionState.Stopped) {
@@ -734,9 +770,66 @@ export abstract class AsciiSession extends FixSession {
     const state = this.sessionState
     state.peerHeartBeatSecs = view.getTyped(MsgTag.HeartBtInt) as number
     state.peerCompId = view.getTyped(MsgTag.SenderCompID) as string
-    const res = this.onLogon(view, userName as string, password as string)
-    // currently not using this.
-    logger.info(`peerLogon onLogon returns ${res}`)
+
+    const verdict = this.onLogon(view, userName as string, password as string)
+    if (typeof verdict === 'boolean') {
+      // the common case - finish the handshake in this same event, so an application
+      // with a synchronous onLogon sees exactly the timing it always has
+      this.completePeerLogon(view, verdict, resetSeqNumFlag)
+      return
+    }
+    this.awaitLogonVerdict(view, verdict, resetSeqNumFlag)
+  }
+
+  /**
+   * onLogon handed back a promise - the application is checking the credentials
+   * against something asynchronous.  Nothing may be sent or acted on until it
+   * answers, so pause the socket and queue whatever the peer says in the meantime.
+   *
+   * The view has to be cloned: AsciiParser recycles its tag index and buffer as soon
+   * as the current event returns, so the original is meaningless by the time the
+   * promise settles.  Anything already read off it - peerReset here - is carried
+   * across as a value rather than read again from the clone.
+   */
+  private awaitLogonVerdict (view: MsgView, verdict: Promise<boolean>, peerReset: boolean | undefined): void {
+    const logger = this.sessionLogger
+    logger.info('onLogon returned a promise - awaiting logon verdict')
+    this.logonVerdictPending = true
+    const logon = view.clone()
+    this.transport?.duplex.readable?.pause()
+
+    verdict.then((accepted: boolean) => {
+      this.logonVerdictPending = false
+      if (this.sessionState.state === SessionState.Stopped) {
+        logger.info('session stopped while awaiting logon verdict - discarding')
+        this.pendingRx.length = 0
+        return
+      }
+      this.completePeerLogon(logon, accepted, peerReset)
+      if (!accepted) {
+        // completePeerLogon has torn the session down - nothing queued can be acted on
+        this.pendingRx.length = 0
+        return
+      }
+      this.resumeRx()
+    }).catch((e: Error) => {
+      this.logonVerdictPending = false
+      this.pendingRx.length = 0
+      // a credential check that throws is a refusal, not a reason to let the peer in
+      this.rejectLogon(`onLogon failed: ${e.message}`)
+    })
+  }
+
+  /**
+   * The application has accepted or refused the peer - finish the handshake either way.
+   */
+  private completePeerLogon (view: MsgView, accepted: boolean, peerReset: boolean | undefined): void {
+    const logger = this.sessionLogger
+    logger.info(`peerLogon onLogon returns ${accepted}`)
+    if (!accepted) {
+      this.rejectLogon('logon rejected by application')
+      return
+    }
     if (this.acceptor) {
       this.setState(SessionState.InitiationLogonResponse)
       logger.info('acceptor responds to logon request')
@@ -745,7 +838,7 @@ export abstract class AsciiSession extends FixSession {
       // reset our sequences before sending our logon response.
       // This handles the broker-reset pattern where client sends N, we respond with Y.
       const weReset = this.config.description.ResetSeqNumFlag
-      if (weReset && resetSeqNumFlag !== true) {
+      if (weReset && peerReset !== true) {
         logger.info('acceptor sending ResetSeqNumFlag=Y (peer sent N), resetting sequences')
         // Fire-and-forget async coordinator call, set values synchronously
         this.coordinator.resetAsAcceptor().catch((e: Error) => {
@@ -764,7 +857,7 @@ export abstract class AsciiSession extends FixSession {
         }
       }
 
-      this.sendLogon() // if res send response else reject, terminate
+      this.sendLogon()
     } else { // as an initiator the acceptor has responded
       logger.info('initiator receives logon response')
       this.setState(SessionState.InitiationLogonReceived)
@@ -777,6 +870,21 @@ export abstract class AsciiSession extends FixSession {
     }
     logger.info('system ready, inform app')
     this.onReady(view)
+  }
+
+  /**
+   * The application refused this peer.  FIX expects the refusing side to say why and
+   * then hang up rather than simply going quiet, so send a Logout carrying the reason
+   * before dropping the transport - the order matters, send() discards anything
+   * offered once the session has stopped.
+   *
+   * onReady is never reached and no heartbeat timer starts; the application learns the
+   * outcome through onStopped(error).
+   */
+  private rejectLogon (reason: string): void {
+    this.sessionLogger.warning(`refusing peer logon: ${reason}`)
+    this.sendLogout(reason)
+    this.terminate(new Error(reason))
   }
 
   private sendTestRequest (): void {

--- a/src/transport/session/fix-session.ts
+++ b/src/transport/session/fix-session.ts
@@ -631,11 +631,21 @@ export abstract class FixSession extends events.EventEmitter {
    */
   protected abstract onStopped (error?: Error): void
   /**
-   * Placeholder infomring the application of a peer login attempt.
+   * Inform the application of a peer login attempt and ask it to accept or reject.
+   *
+   * Return true to let the session continue.  Return false to refuse the peer: a
+   * Logout carrying a Text reason is sent and the transport is dropped, so onReady
+   * is never reached and no heartbeat is started.
+   *
+   * The verdict may be returned as a promise, for applications that must check the
+   * credentials against an async source such as an http api or a database.  While
+   * that promise is pending the transport is paused and any message the peer sends
+   * is queued, then replayed in order once the verdict arrives.
+   *
    * @param view the login message
    * @param user extracted user from message
    * @param password extracted password from the message.
    * @protected
    */
-  protected abstract onLogon (view: MsgView, user: string, password: string): boolean
+  protected abstract onLogon (view: MsgView, user: string, password: string): boolean | Promise<boolean>
 }


### PR DESCRIPTION
Closes #19, closes #64. Both issues meet at one call site, so they are fixed together.

## The state of things

`AsciiSession.peerLogon` called `onLogon`, logged the answer and dropped it:

```ts
const res = this.onLogon(view, userName as string, password as string)
// currently not using this.
logger.info(`peerLogon onLogon returns ${res}`)
```

Returning `false` did nothing — the logon response still went out, the heartbeat still started, `onReady` still fired. That is #19, and the 2021 comment on that issue ("we do not yet reject or disconnect if false is returned") still described the code exactly.

The hook was also synchronous, so credentials could not be checked against an http api, a database or a secrets store. That is #64.

## What changed

**The verdict is honoured.** `false` sends the peer a `Logout` carrying the reason and then drops the transport. `onReady` is never reached, no heartbeat starts, and the application learns the outcome through `onStopped(error)`. Sending before terminating matters — `send()` discards anything offered once the session has stopped.

**The verdict may be a promise.** The abstract widens to `boolean | Promise<boolean>`, which every existing subclass satisfies unchanged:

```ts
protected async onLogon (view: MsgView, user: string, password: string): Promise<boolean> {
  const account = await this.directory.lookup(user)
  return account?.enabled === true && await account.verify(password)
}
```

A plain boolean still completes the handshake in the same event, so a synchronous application keeps exactly the timing it had — no microtask is injected into the common path.

A promise pauses the transport and queues whatever the peer sends behind its Logon, replaying it in order once the verdict arrives. This reuses the gate built for wildcard identity binding rather than inventing one: a TCP segment can carry several messages and the parser emits them all in one synchronous burst, so a view cannot survive an `await` without being cloned. `resumeRx`/`rxGated` let the two gates coexist — an application with an async `onLogon` on a wildcard acceptor closes the second gate before the first has opened.

A rejected promise refuses the peer rather than letting it in, and its message is carried through to the Logout.

## Drive-by fix

`AsciiSessionMsgFactory.logout` took the text alone:

```ts
public logout (text: string): ILooseObject
```

while `ISessionMsgFactory` declares `(msgType, text)` and `FixSession.sendLogout` calls it that way. TypeScript accepts the narrower override, so the msg type bound to `Text` and the caller's message was dropped — **every** Logout jspurefix sent carried `58=5` rather than the reason. The refusal path needs that text to reach the peer, so it is fixed here.

## Behaviour change

An application that returns `false` from `onLogon` today gets a session anyway. After this change it gets a disconnect — which is the fix, but it is a real change for anyone who was returning `false` casually. Every implementation in this repo (nine samples, two tests) returns `true`, so nothing here moves.

## Known wrinkle

If a Logon arrives with a sequence gap *and* the application returns a promise, `checkSeqNo` still sends its ResendRequest before the verdict lands. The resent messages are queued by the gate and replayed correctly, so nothing is lost or reordered — but a message does go out before the peer has been accepted. Left as is rather than restructuring `checkSeqNo`.

## Tests

`src/test/session/logon-verdict.test.ts`, seven cases: sync true unchanged; sync false refuses from either side; async true completes on arrival; async false refuses; a rejected promise refuses; and a Logon plus two TestRequests delivered in one push are held while the verdict is outstanding, then answered in the order the peer sent them.

Full suite green — 657 tests, 64 suites. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
