### PR TITLE
feat(initiator): make the reconnect policy configurable and stoppable (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A fast, fully native TypeScript [FIX protocol](https://www.fixtrading.org/) engi
 - [Quickstart](#quickstart)
 - [Session Configuration](#session-configuration)
   - [Customising the Logon](#customising-the-logon)
+  - [Reconnecting initiators](#reconnecting-initiators)
+  - [Knowing when the session is up](#knowing-when-the-session-is-up)
   - [Accepting or refusing a logon](#accepting-or-refusing-a-logon)
   - [TLS](#tls)
   - [Body length padding](#body-length-padding)
@@ -168,6 +170,50 @@ Most counterparties want a tag on the Logon the standard message does not carry.
 ```
 
 A field named here must also be declared on `Logon` in the dictionary the session loads, or the encoder has no tag to write it to and will say so in the log. For values computed at run time, or for a header a counterparty stamps differently, supply your own session message factory. See [docs/custom-logon.md](docs/custom-logon.md) for the whole picture.
+
+### Reconnecting initiators
+
+By default an initiator makes one connection and its `run()` ends when that session does. Set `resilient` and it keeps the same session across transports instead — losing the connection schedules another attempt, and the session resumes with the recovery policy configured on the description (replay from the last sequence number, or a reset).
+
+```json
+{
+  "application": {
+    "type": "initiator",
+    "name": "test_client",
+    "resilient": true,
+    "reconnectSeconds": 10,
+    "connectTimeoutSeconds": 60,
+    "recoveryAttemptSeconds": 5,
+    "backoffFailConnectSeconds": 30,
+    "tcp": { "host": "localhost", "port": 2344 },
+    "protocol": "ascii",
+    "dictionary": "repo44"
+  }
+}
+```
+
+| field | applies to | meaning | default |
+| --- | --- | --- | --- |
+| `resilient` | initiator | re-establish a lost transport and resume the same session | `false` |
+| `reconnectSeconds` | initiator | wait between attempts whilst trying to establish a connection | `5` |
+| `connectTimeoutSeconds` | initiator | how long to keep attempting before giving up | `60` resilient, `22` otherwise |
+| `recoveryAttemptSeconds` | resilient only | wait after losing the transport before trying to get it back | `5` |
+| `backoffFailConnectSeconds` | resilient only | wait after a failed recovery before trying again | `30` |
+
+Call `stop()` on the launcher to give up: it cancels any pending recovery and ends the session, which is what lets the process exit. Without it a resilient initiator keeps trying for as long as it is running.
+
+### Knowing when the session is up
+
+`SessionLauncher.run()` is the lifetime of the application, not a signal that the session is ready. For an initiator it resolves when the session **ends**; it rejects if the first connection cannot be established within `connectTimeoutSeconds`. A resilient initiator does not resolve on a dropped connection at all — getting it back is the whole point — so it resolves only once you `stop()` it or the session ends for good.
+
+To act when the session comes up, use `onReady` on your session class:
+
+```ts
+protected onReady (_view: MsgView): void {
+  // logged on - safe to send
+  this.send(MsgType.MarketDataRequest, this.subscription())
+}
+```
 
 ### Accepting or refusing a logon
 

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -57,6 +57,7 @@ export abstract class SessionLauncher {
   }
 
   private acceptorEntity: FixEntity | null = null
+  private initiatorEntity: FixEntity | null = null
   private stopRequested: boolean = false
 
   protected async getAcceptor (sessionContainer: DependencyContainer): Promise<any> {
@@ -78,6 +79,11 @@ export abstract class SessionLauncher {
   protected async getInitiator (sessionContainer: DependencyContainer): Promise<any> {
     if (sessionContainer.isRegistered<FixEntity>(DITokens.FixEntity)) {
       const entity = sessionContainer.resolve<FixEntity>(DITokens.FixEntity)
+      this.initiatorEntity = entity
+      if (this.stopRequested) {
+        this.logger.info('stop requested before the initiator started - not connecting')
+        return this.empty()
+      }
       return entity.start()
     } else {
       return this.empty()
@@ -95,7 +101,8 @@ export abstract class SessionLauncher {
   }
 
   /**
-   * Stop what this launcher started - in practice, close the acceptor's listener.
+   * Stop what this launcher started - close the acceptor's listener, and give up a
+   * resilient initiator's attempts to get its transport back.
    *
    * An acceptor is meant to outlive any one counterparty, so nothing closes its
    * listener on its own.  That is right for a venue and wrong for an application
@@ -107,12 +114,18 @@ export abstract class SessionLauncher {
    * usual arrangement as soon as more than one client is involved.  There was then
    * no way to shut a listener down short of killing the process.
    *
-   * Safe before start (the request is remembered and the listener never opens), and
-   * safe to call twice.  run() resolves once the listener has closed.
+   * A resilient initiator had the same problem from the other side: losing the
+   * transport schedules another attempt, so it too kept the process alive with no way
+   * to call it off.  See issue #72.
+   *
+   * Safe before start (the request is remembered and neither is opened), and safe to
+   * call twice.  run() resolves once the listener has closed and the initiator has
+   * given up.
    */
   public stop (): void {
     this.stopRequested = true
     this.stopAcceptor()
+    this.stopInitiator()
   }
 
   public async run (): Promise<boolean> {
@@ -224,6 +237,15 @@ export abstract class SessionLauncher {
 
   private stopAcceptor (): void {
     const entity = this.acceptorEntity as any
+    if (entity && typeof entity.stop === 'function') {
+      entity.stop()
+    }
+  }
+
+  // only a resilient initiator has anything to call off - a plain one ends with its
+  // session, so it has no stop to find here
+  private stopInitiator (): void {
+    const entity = this.initiatorEntity as any
     if (entity && typeof entity.stop === 'function') {
       entity.stop()
     }

--- a/src/test/session/reconnect-policy.test.ts
+++ b/src/test/session/reconnect-policy.test.ts
@@ -1,0 +1,280 @@
+import 'reflect-metadata'
+
+import * as net from 'net'
+import * as path from 'path'
+import { DependencyContainer } from 'tsyringe'
+import { SessionLauncher } from '../../runtime/session-launcher'
+import { EngineFactory } from '../../runtime/engine-factory'
+import { DITokens } from '../../runtime/di-tokens'
+import { EmptyLogFactory, IJsFixConfig } from '../../config'
+import { AsciiSession, ISessionDescription } from '../../transport'
+import { FixEntity } from '../../transport/fix-entity'
+import { RecoveringTcpInitiator } from '../../transport/tcp/recovering-tcp-initiator'
+import { TcpInitiatorConnector } from '../../transport/tcp/tcp-initiator-connector'
+import { MsgView } from '../../buffer'
+
+/**
+ * The retry policy of an initiator.
+ *
+ * `resilient` picks the initiator that re-establishes a lost transport, and its
+ * timings used to live in fields nothing ever wrote:
+ *
+ *   public recoveryAttemptSecs: number = 5
+ *   public backoffFailConnectSecs: number = 30
+ *
+ * with the connect timeout hard coded at the call sites (60 here, 22 in the plain
+ * connector).  So an application could not say how hard or how long to try without
+ * subclassing the launcher and poking the resolved instance - which is what
+ * https://github.com/TimelordUK/jspurefix/issues/72 was about.
+ */
+
+const initiatorTemplate: ISessionDescription =
+  require(path.join(__dirname, '../../../data/session/test-initiator.json'))
+
+const acceptorTemplate: ISessionDescription =
+  require(path.join(__dirname, '../../../data/session/test-acceptor.json'))
+
+/** logs on, does nothing, and records when it became ready */
+class QuietSession extends AsciiSession {
+  public readyCount: number = 0
+
+  constructor (config: IJsFixConfig) {
+    super(config)
+    this.heartbeat = false
+  }
+
+  protected onApplicationMsg (_msgType: string, _view: MsgView): void {}
+  protected onDecoded (_msgType: string, _txt: string): void {}
+  protected onEncoded (_msgType: string, _txt: string): void {}
+  protected onReady (_view: MsgView): void {
+    this.readyCount++
+  }
+
+  protected onStopped (_error?: Error): void {}
+  protected onLogon (_view: MsgView, _user: string, _password: string): boolean {
+    return true
+  }
+}
+
+/**
+ * Builds the initiator exactly as an application would, then stops short of
+ * connecting - the entity is the subject here, not the socket.
+ */
+class CapturingLauncher extends SessionLauncher {
+  public entity: FixEntity | null = null
+
+  constructor (description: ISessionDescription) {
+    super(description, null, new EmptyLogFactory())
+  }
+
+  protected override makeFactory (_config: IJsFixConfig): EngineFactory {
+    return {
+      makeSession: (sessionConfig: IJsFixConfig) => new QuietSession(sessionConfig)
+    }
+  }
+
+  protected override async getInitiator (sessionContainer: DependencyContainer): Promise<any> {
+    this.entity = sessionContainer.resolve<FixEntity>(DITokens.FixEntity)
+    return null
+  }
+}
+
+function initiatorDescription (application: Record<string, any>): ISessionDescription {
+  return {
+    ...initiatorTemplate,
+    application: {
+      ...initiatorTemplate.application,
+      ...application
+    }
+  } as ISessionDescription
+}
+
+async function initiatorFrom (application: Record<string, any>): Promise<FixEntity> {
+  const launcher = new CapturingLauncher(initiatorDescription(application))
+  await launcher.run()
+  expect(launcher.entity).toBeTruthy()
+  return launcher.entity!
+}
+
+test('a resilient initiator takes its retry policy from the session description', async () => {
+  const entity = await initiatorFrom({
+    resilient: true,
+    connectTimeoutSeconds: 12,
+    recoveryAttemptSeconds: 2,
+    backoffFailConnectSeconds: 7
+  })
+
+  expect(entity).toBeInstanceOf(RecoveringTcpInitiator)
+  const initiator = entity as RecoveringTcpInitiator
+  expect(initiator.connectTimeoutSecs).toBe(12)
+  expect(initiator.recoveryAttemptSecs).toBe(2)
+  expect(initiator.backoffFailConnectSecs).toBe(7)
+})
+
+test('a resilient initiator keeps its old defaults when the description says nothing', async () => {
+  const entity = await initiatorFrom({ resilient: true })
+
+  const initiator = entity as RecoveringTcpInitiator
+  expect(initiator.connectTimeoutSecs).toBe(RecoveringTcpInitiator.DefaultConnectTimeoutSecs)
+  expect(initiator.recoveryAttemptSecs).toBe(RecoveringTcpInitiator.DefaultRecoveryAttemptSecs)
+  expect(initiator.backoffFailConnectSecs).toBe(RecoveringTcpInitiator.DefaultBackoffFailConnectSecs)
+  // the values the engine has always used - this test exists to keep them that way
+  expect(initiator.connectTimeoutSecs).toBe(60)
+  expect(initiator.recoveryAttemptSecs).toBe(5)
+  expect(initiator.backoffFailConnectSecs).toBe(30)
+})
+
+test('resilient false still gives the single connection initiator', async () => {
+  const entity = await initiatorFrom({ resilient: false })
+  expect(entity).toBeInstanceOf(TcpInitiatorConnector)
+})
+
+test('a plain initiator takes its connect timeout from the session description', async () => {
+  const entity = await initiatorFrom({ connectTimeoutSeconds: 9 })
+
+  expect(entity).toBeInstanceOf(TcpInitiatorConnector)
+  expect((entity as TcpInitiatorConnector).connectTimeoutSecs).toBe(9)
+})
+
+test('a plain initiator keeps its old default when the description says nothing', async () => {
+  const entity = await initiatorFrom({})
+
+  const connector = entity as TcpInitiatorConnector
+  expect(connector.connectTimeoutSecs).toBe(TcpInitiatorConnector.DefaultConnectTimeoutSecs)
+  expect(connector.connectTimeoutSecs).toBe(22)
+})
+
+/** counts the sessions handed out - one per accepted connection */
+class CountingAcceptorLauncher extends SessionLauncher {
+  public readonly sessions: QuietSession[] = []
+
+  constructor (description: ISessionDescription) {
+    super(null, description, new EmptyLogFactory())
+  }
+
+  protected override makeFactory (_config: IJsFixConfig): EngineFactory {
+    return {
+      makeSession: (sessionConfig: IJsFixConfig) => {
+        const session = new QuietSession(sessionConfig)
+        this.sessions.push(session)
+        return session
+      }
+    }
+  }
+}
+
+class RealInitiatorLauncher extends SessionLauncher {
+  public readonly sessions: QuietSession[] = []
+
+  constructor (description: ISessionDescription) {
+    super(description, null, new EmptyLogFactory())
+  }
+
+  protected override makeFactory (_config: IJsFixConfig): EngineFactory {
+    return {
+      makeSession: (sessionConfig: IJsFixConfig) => {
+        const session = new QuietSession(sessionConfig)
+        this.sessions.push(session)
+        return session
+      }
+    }
+  }
+}
+
+function acceptorDescription (port: number): ISessionDescription {
+  return {
+    ...acceptorTemplate,
+    application: {
+      ...acceptorTemplate.application,
+      tcp: { host: '127.0.0.1', port }
+    }
+  } as ISessionDescription
+}
+
+/** a free port, discovered by binding one and giving it straight back */
+async function freePort (): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const probe = net.createServer()
+    probe.once('error', reject)
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address()
+      const port = typeof address === 'object' && address !== null ? address.port : 0
+      probe.close(() => { resolve(port) })
+    })
+  })
+}
+
+async function waitFor (predicate: () => boolean, what: string, timeoutMs = 15000): Promise<void> {
+  const start = Date.now()
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timed out waiting for ${what}`)
+    }
+    await new Promise<void>(resolve => { setTimeout(resolve, 20) })
+  }
+}
+
+test('a resilient initiator gets its transport back on the configured schedule', async () => {
+  const port = await freePort()
+
+  const acceptor = new CountingAcceptorLauncher(acceptorDescription(port))
+  const acceptorRun = acceptor.run().catch((e: Error) => e)
+  await waitFor(() => acceptor.sessions.length >= 0, 'acceptor start')
+
+  const initiator = new RealInitiatorLauncher(initiatorDescription({
+    resilient: true,
+    connectTimeoutSeconds: 10,
+    recoveryAttemptSeconds: 1,
+    reconnectSeconds: 1,
+    tcp: { host: '127.0.0.1', port }
+  }))
+  const initiatorRun = initiator.run().catch((e: Error) => e)
+
+  await waitFor(() => acceptor.sessions.length === 1 && acceptor.sessions[0].readyCount === 1,
+    'first session logged on')
+
+  // the counterparty vanishes - the sort of thing resilient exists for
+  acceptor.sessions[0].requestStop('simulating a dropped connection')
+
+  // recoveryAttemptSeconds is 1, so a second connection should be accepted well inside
+  // the default 5 this test would otherwise have had to wait for
+  await waitFor(() => acceptor.sessions.length === 2 && acceptor.sessions[1].readyCount === 1,
+    'reconnect and second logon')
+
+  // and it is the same session object throughout - the point of a resilient initiator
+  // is that the session survives the transport
+  expect(initiator.sessions.length).toBe(1)
+  expect(initiator.sessions[0].readyCount).toBe(2)
+
+  // and it can be called off - before this, losing the transport always scheduled
+  // another attempt, so a resilient initiator held the process open for good
+  initiator.stop()
+  acceptor.stop()
+  await Promise.all([acceptorRun, initiatorRun])
+}, 40000)
+
+test('a resilient initiator gives up when the launcher is stopped', async () => {
+  const port = await freePort()
+
+  // nothing is listening on this port, so the initiator can only sit in its retry
+  // loop - which is exactly the state that used to be impossible to leave
+  const initiator = new RealInitiatorLauncher(initiatorDescription({
+    resilient: true,
+    connectTimeoutSeconds: 5,
+    recoveryAttemptSeconds: 1,
+    reconnectSeconds: 1,
+    tcp: { host: '127.0.0.1', port }
+  }))
+
+  let settled = false
+  const run = initiator.run().catch((e: Error) => e).then(r => {
+    settled = true
+    return r
+  })
+
+  await new Promise<void>(resolve => { setTimeout(resolve, 500) })
+  expect(settled).toBe(false)
+
+  initiator.stop()
+  await waitFor(() => settled, 'run to settle after stop', 10000)
+}, 30000)

--- a/src/test/session/reconnect-policy.test.ts
+++ b/src/test/session/reconnect-policy.test.ts
@@ -219,8 +219,9 @@ test('a resilient initiator gets its transport back on the configured schedule',
 
   const acceptor = new CountingAcceptorLauncher(acceptorDescription(port))
   const acceptorRun = acceptor.run().catch((e: Error) => e)
-  await waitFor(() => acceptor.sessions.length >= 0, 'acceptor start')
 
+  // no need to wait for the listener - reconnectSeconds paces the initiator's attempts
+  // inside its connect timeout, so it simply retries until the acceptor is up
   const initiator = new RealInitiatorLauncher(initiatorDescription({
     resilient: true,
     connectTimeoutSeconds: 10,
@@ -230,27 +231,36 @@ test('a resilient initiator gets its transport back on the configured schedule',
   }))
   const initiatorRun = initiator.run().catch((e: Error) => e)
 
-  await waitFor(() => acceptor.sessions.length === 1 && acceptor.sessions[0].readyCount === 1,
-    'first session logged on')
+  try {
+    await waitFor(() => acceptor.sessions.length === 1 && acceptor.sessions[0].readyCount === 1,
+      'first session logged on')
 
-  // the counterparty vanishes - the sort of thing resilient exists for
-  acceptor.sessions[0].requestStop('simulating a dropped connection')
+    // the counterparty vanishes - the sort of thing resilient exists for
+    acceptor.sessions[0].requestStop('simulating a dropped connection')
 
-  // recoveryAttemptSeconds is 1, so a second connection should be accepted well inside
-  // the default 5 this test would otherwise have had to wait for
-  await waitFor(() => acceptor.sessions.length === 2 && acceptor.sessions[1].readyCount === 1,
-    'reconnect and second logon')
+    // recoveryAttemptSeconds is 1, so a second connection should be accepted well
+    // inside the default 5 this test would otherwise have had to wait for.
+    //
+    // Wait on the initiator, not the acceptor.  An acceptor is ready the moment it has
+    // sent its logon response, whilst the initiator is ready only once that response
+    // has crossed back and been processed - so the two are never ready in the same
+    // turn, and asserting the initiator's count off the acceptor's readiness is a race
+    // that loopback hides on a quiet machine and a loaded CI runner does not.
+    await waitFor(() => initiator.sessions[0]?.readyCount === 2,
+      'initiator logged on again over a new transport')
 
-  // and it is the same session object throughout - the point of a resilient initiator
-  // is that the session survives the transport
-  expect(initiator.sessions.length).toBe(1)
-  expect(initiator.sessions[0].readyCount).toBe(2)
-
-  // and it can be called off - before this, losing the transport always scheduled
-  // another attempt, so a resilient initiator held the process open for good
-  initiator.stop()
-  acceptor.stop()
-  await Promise.all([acceptorRun, initiatorRun])
+    // it is the same session object throughout - the point of a resilient initiator is
+    // that the session survives the transport
+    expect(initiator.sessions.length).toBe(1)
+    expect(acceptor.sessions.length).toBe(2)
+  } finally {
+    // in a finally so a failed assertion still releases the listener and the recovery
+    // timer.  Leaking those does not just affect this test - jest cannot exit, and the
+    // whole run hangs on a runner that has no terminal to interrupt it
+    initiator.stop()
+    acceptor.stop()
+    await Promise.all([acceptorRun, initiatorRun])
+  }
 }, 40000)
 
 test('a resilient initiator gives up when the launcher is stopped', async () => {
@@ -272,9 +282,19 @@ test('a resilient initiator gives up when the launcher is stopped', async () => 
     return r
   })
 
-  await new Promise<void>(resolve => { setTimeout(resolve, 500) })
-  expect(settled).toBe(false)
+  try {
+    await new Promise<void>(resolve => { setTimeout(resolve, 500) })
+    // still retrying - nothing is listening, and the 5s connect timeout has not run out
+    const settledBeforeStop = settled
 
-  initiator.stop()
-  await waitFor(() => settled, 'run to settle after stop', 10000)
+    initiator.stop()
+    await waitFor(() => settled, 'run to settle after stop', 10000)
+
+    // asserted after the stop rather than before it, so a failure here cannot skip the
+    // stop and leave the retry loop running for the rest of the suite
+    expect(settledBeforeStop).toBe(false)
+  } finally {
+    initiator.stop()
+    await run
+  }
 }, 30000)

--- a/src/transport/msg-application.ts
+++ b/src/transport/msg-application.ts
@@ -4,8 +4,24 @@ import { IHttpTransportDescription } from './http/http-transport-description'
 export interface IMsgApplication {
   readonly name: string
   readonly type: string
+  /**
+   * An initiator which re-establishes its transport after the connection drops and
+   * resumes the same session, rather than ending when the socket does.  Defaults to
+   * false, which gives a single connection.  See "Reconnecting initiators" in the
+   * README for the retry policy below.
+   */
   readonly resilient: boolean
+  /** how long to wait between attempts whilst trying to establish a connection.  Defaults to 5. */
   readonly reconnectSeconds: number
+  /**
+   * how long to keep attempting a connection before giving up.  Defaults to 60 for a
+   * resilient initiator and 22 for a plain one.
+   */
+  readonly connectTimeoutSeconds?: number
+  /** resilient only: how long after losing the transport before trying to get it back.  Defaults to 5. */
+  readonly recoveryAttemptSeconds?: number
+  /** resilient only: how long to wait after a failed recovery before trying again.  Defaults to 30. */
+  readonly backoffFailConnectSeconds?: number
   readonly tcp?: ITcpTransportDescription
   readonly http?: IHttpTransportDescription
   readonly protocol: string

--- a/src/transport/tcp/recovering-tcp-initiator.ts
+++ b/src/transport/tcp/recovering-tcp-initiator.ts
@@ -25,8 +25,14 @@ export class RecoveringTcpInitiator extends FixEntity {
   private initiator: TcpInitiator
   private transport: MsgTransport
   private th: Timeout | null = null
-  public recoveryAttemptSecs: number = 5
-  public backoffFailConnectSecs: number = 30
+  private stopRequested: boolean = false
+  public static readonly DefaultRecoveryAttemptSecs = 5
+  public static readonly DefaultBackoffFailConnectSecs = 30
+  public static readonly DefaultConnectTimeoutSecs = 60
+
+  public recoveryAttemptSecs: number = RecoveringTcpInitiator.DefaultRecoveryAttemptSecs
+  public backoffFailConnectSecs: number = RecoveringTcpInitiator.DefaultBackoffFailConnectSecs
+  public connectTimeoutSecs: number = RecoveringTcpInitiator.DefaultConnectTimeoutSecs
 
   constructor (@inject(DITokens.IJsFixConfig) public readonly jsFixConfig: IJsFixConfig) {
     super(jsFixConfig)
@@ -40,6 +46,14 @@ export class RecoveringTcpInitiator extends FixEntity {
     if (!this.tcp) {
       throw new Error('no tcp in session description need tcp { host: hostname, port: port }')
     }
+    // the retry policy used to live only in these fields, which nothing set - an
+    // application could not change how hard or how long the engine tried to get its
+    // transport back without subclassing the launcher.  See issue #72.
+    this.recoveryAttemptSecs = this.application.recoveryAttemptSeconds ?? this.recoveryAttemptSecs
+    this.backoffFailConnectSecs = this.application.backoffFailConnectSeconds ?? this.backoffFailConnectSecs
+    this.connectTimeoutSecs = this.application.connectTimeoutSeconds ?? this.connectTimeoutSecs
+    this.logger.info(`recovery policy: connectTimeout=${this.connectTimeoutSecs}s, ` +
+      `recoveryAttempt=${this.recoveryAttemptSecs}s, backoffFailConnect=${this.backoffFailConnectSecs}s`)
     this.createSession(jsFixConfig)
   }
 
@@ -53,6 +67,13 @@ export class RecoveringTcpInitiator extends FixEntity {
     this.session.on('end', () => {
       this.logger.info('session has permanently ended')
       this.emit('end', this)
+    })
+    // A lost transport is this initiator's normal course of events, and recovery is
+    // driven by session.run() rejecting rather than by this event.  But whilst waiting
+    // between attempts there is no run in flight to carry a listener, so a stop landing
+    // then would emit 'error' to nobody - which node treats as fatal.
+    this.session.on('error', (e: Error) => {
+      this.logger.info(`session error: ${e.message}`)
     })
     this.session.setState(SessionState.DisconnectedNoConnectionToday)
   }
@@ -104,7 +125,31 @@ export class RecoveringTcpInitiator extends FixEntity {
   // succeed in which case can restart session or fails in which case wait and
   // restart an attempt to connect
 
+  /**
+   * Give up recovering and end the session for good.
+   *
+   * Without this a resilient initiator could not be shut down: losing the transport
+   * schedules another attempt, and nothing cancelled that timer, so the process stayed
+   * alive retrying a counterparty the application had finished with.  Safe to call
+   * twice, and safe whilst waiting between attempts with no transport at all.
+   */
+  public stop (): void {
+    if (this.stopRequested) return
+    this.stopRequested = true
+    this.logger.info('stop requested - cancelling recovery')
+    this.clearTimer()
+    if (this.session.getState() !== SessionState.Stopped) {
+      this.session.requestStop('initiator stopped')
+    }
+    this.emit('end', this)
+  }
+
   private recover (): void {
+    if (this.stopRequested) {
+      this.logger.info('transport lost after a stop was requested - not recovering')
+      this.emit('end', this)
+      return
+    }
     this.session.setState(SessionState.DetectBrokenNetworkConnection)
     this.logger.info(`recover session transport - attempt in ${this.recoveryAttemptSecs} secs`)
     if (!this.resetSeq()) {
@@ -115,7 +160,7 @@ export class RecoveringTcpInitiator extends FixEntity {
       }
     }
     this.th = setTimeout(() => {
-      this.connect(60).then(t => {
+      this.connect(this.connectTimeoutSecs).then(t => {
         this.logger.info(`new transport ${t.id}`)
       }).catch((e) => {
         this.logger.info(`failed to re-connect ${e.message} - backoff for ${this.backoffFailConnectSecs}`)
@@ -135,18 +180,34 @@ export class RecoveringTcpInitiator extends FixEntity {
 
   // for first connection - reject if no initial connection established within timeout
   // once connection established, will not resolve until session is ended - i.e. lost
-  // connections are re-established using the same session instance.
+  // connections are re-established using the same session instance.  So this promise
+  // is the lifetime of the application, not a signal that the session is up: for that,
+  // use onReady on the session.  See issue #72.
 
-  public async run (initialTimeout: number = 60): Promise<any> {
+  public async run (initialTimeout: number = this.connectTimeoutSecs): Promise<any> {
     return await new Promise<any>((resolve, reject) => {
-      this.connect(initialTimeout).then(() => {
-        this.on('end', () => {
-          this.clearTimer()
-          this.initiator.end()
-          this.logger.info(`run: transport ${this.transport.id} gracefully ends ${initialTimeout} - resolving`)
-          resolve(null)
-        })
-      }).catch(e => {
+      // 'end' can arrive more than once - a stop both ends the session and calls off
+      // recovery, and each path announces itself - so settle only on the first.  The
+      // listener goes on before connecting, not after: a stop landing whilst the first
+      // connection is still being attempted has to be able to end this too, and until
+      // now there was nothing listening that early to hear it.
+      let ended = false
+      const finish = (): void => {
+        if (ended) return
+        ended = true
+        this.clearTimer()
+        this.initiator?.end()
+        this.logger.info(`run: transport ${this.transport?.id ?? 'none'} ends - resolving`)
+        resolve(null)
+      }
+      this.on('end', finish)
+
+      this.connect(initialTimeout).catch(e => {
+        if (this.stopRequested) {
+          this.logger.info('run: first connection abandoned on stop - resolving')
+          finish()
+          return
+        }
         this.logger.info(`run: failed to connect to first transport ${initialTimeout} - rejecting`)
         reject(e)
       })

--- a/src/transport/tcp/tcp-initiator-connector.ts
+++ b/src/transport/tcp/tcp-initiator-connector.ts
@@ -9,8 +9,13 @@ import { FixEntity } from '../fix-entity'
 
 @injectable()
 export class TcpInitiatorConnector extends FixEntity {
+  public static readonly DefaultConnectTimeoutSecs = 22
+
+  public connectTimeoutSecs: number = TcpInitiatorConnector.DefaultConnectTimeoutSecs
+
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig) {
     super(config)
+    this.connectTimeoutSecs = config.description.application?.connectTimeoutSeconds ?? this.connectTimeoutSecs
   }
 
   async start (reconnectTimeout: number = 0): Promise<any> {
@@ -62,7 +67,7 @@ export class TcpInitiatorConnector extends FixEntity {
     const logger = this.config.logFactory.logger('initiator')
     const initiator: FixInitiator = this.config.sessionContainer.resolve<FixInitiator>(TcpInitiator)
     logger.info('connecting ...')
-    const initiatorTransport: MsgTransport = await initiator.connect(22)
+    const initiatorTransport: MsgTransport = await initiator.connect(this.connectTimeoutSecs)
     logger.info('... connected, run session')
     await initiatorSession.run(initiatorTransport)
     logger.info('ends')

--- a/src/transport/tcp/tcp-initiator.ts
+++ b/src/transport/tcp/tcp-initiator.ts
@@ -28,6 +28,7 @@ export class TcpInitiator extends FixInitiator {
   private readonly logger: IJsFixLogger
   private duplex: FixDuplex
   private th: Timeout | null = null
+  private timeoutTh: Timeout | null = null
 
   constructor (@inject(DITokens.IJsFixConfig) public readonly jsFixConfig: IJsFixConfig) {
     super(jsFixConfig.description.application ?? null)
@@ -189,13 +190,15 @@ export class TcpInitiator extends FixInitiator {
       clearInterval(this.th)
       this.th = null
     }
+    if (this.timeoutTh) {
+      clearTimeout(this.timeoutTh)
+      this.timeoutTh = null
+    }
   }
 
   private async repeatConnect (timeoutSeconds: number, initialError?: Error): Promise < MsgTransport > {
     return await new Promise<MsgTransport>(async (resolve, reject) => {
       const application = this.application
-      const promisify = util.promisify
-      const timeoutPromise = promisify(setTimeout)
       const reconnectSeconds = application?.reconnectSeconds ?? 5
       let retries = 0
       let lastError: Error | undefined = initialError
@@ -212,15 +215,18 @@ export class TcpInitiator extends FixInitiator {
             this.logger.info(`${name}: retries ${retries} ${e.message}`)
           })
       }, reconnectSeconds * 1000)
-      timeoutPromise(timeoutSeconds * 1000).then(() => {
+      // a plain timer, not a promisified one: promisify(setTimeout) hands back no
+      // handle, so this deadline could never be cancelled.  Connecting successfully
+      // cleared the retry interval and left this one running to its full term - up to
+      // the 60s an initiator allows - holding the event loop open long after the
+      // session was up, and stopping a process (or a test runner) from exiting.
+      this.timeoutTh = setTimeout(() => {
         this.clearTimer()
         this.state = InitiatorState.Stopped
         const e = lastError ?? new Error(`${name}: timeout of ${timeoutSeconds} whilst connecting`)
         this.logger.warning(`${name}: giving up after ${timeoutSeconds}s and ${retries} retries, last error: ${e.message}`)
         reject(e)
-      }).catch(e => {
-        reject(e)
-      })
+      }, timeoutSeconds * 1000)
     })
   }
 }


### PR DESCRIPTION
Closes #72.

The report had two halves. One is a misunderstanding worth answering; the other was a real gap, and turned out to have a third problem sitting behind it.

## "run() never resolves when connection established"

Working as intended, and still true. `run()` is the lifetime of the application, not a signal that the session is ready — for an initiator it resolves when the session *ends*, and a resilient one does not resolve on a dropped connection at all, because getting it back is the point.

The hook the reporter wanted is `onReady` on the session. That was never written down, so the README now has a **Knowing when the session is up** section saying what `run()` does and does not tell you, and the comment on `RecoveringTcpInitiator.run` says it too.

## "no way to configure how often and how long to retry"

This was real. The policy lived entirely in two fields that nothing ever wrote:

```ts
public recoveryAttemptSecs: number = 5
public backoffFailConnectSecs: number = 30
```

with the connect timeout hard coded at the call sites — `this.connect(60)` in the recovering initiator, `initiator.connect(22)` in the plain connector. The only way to change any of it was to override `getInitiator` in a launcher subclass and poke the resolved entity.

Three new optional fields on the session description, each defaulting to exactly what the engine used before, so no existing config changes behaviour:

| field | applies to | default |
| --- | --- | --- |
| `connectTimeoutSeconds` | initiator | `60` resilient, `22` otherwise |
| `recoveryAttemptSeconds` | resilient only | `5` |
| `backoffFailConnectSeconds` | resilient only | `30` |

`reconnectSeconds` already worked — it paces attempts *within* a connect — but was only ever visible as an unexplained line in a sample JSON, so it is now documented alongside the rest.

## The one behind it: a resilient initiator could not be stopped

Found while writing the reconnect test, which hung on teardown. Losing the transport always schedules another attempt, and nothing cancelled that timer — `SessionLauncher.stop()` only ever reached the acceptor's listener. So a resilient initiator kept the process alive retrying a counterparty the application had finished with, with no way to call it off short of killing the process. That is the same complaint from the other side: no control over how long it retries.

- `RecoveringTcpInitiator.stop()` cancels recovery and ends the session; safe twice, and safe between attempts when there is no transport at all.
- `SessionLauncher.stop()` now reaches the initiator as well as the listener.
- `run()` registers its `end` listener *before* connecting rather than after, so a stop arriving whilst the first connection is still being attempted is heard — previously nothing was listening that early.
- The session gets an `error` listener. Recovery is driven by `session.run()` rejecting rather than that event, but between attempts there is no run in flight to carry a listener, so a stop landing then emitted `'error'` to nobody — which node treats as fatal.

## Discoverability

`resilient` appeared in exactly two places in the whole repo: its declaration on `IMsgApplication` and the line that reads it. No sample config set it, no README section mentioned it, no test covered it. A user wanting a reconnecting initiator had no way to find out it existed — which plausibly explains why the reporter was building their own retry loop around `run()` in the first place. There is now a **Reconnecting initiators** section with the flag, the full table of knobs, and the note that `stop()` is what lets the process exit.

## Tests

`src/test/session/reconnect-policy.test.ts`, seven cases: each knob reaching the resilient initiator and the plain connector; the old defaults pinned by value so they cannot drift; `resilient` selecting the right entity; a real acceptor/initiator pair where the counterparty is dropped and the initiator reconnects on the configured 1s schedule with the same session object across both transports; and a stop landing whilst it is retrying a port nothing is listening on.

Full suite green — 664 tests, 65 suites. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
