### PR TITLE
fix(initiator): report why a connection failed

### DIFF
--- a/src/test/tcp/connect-error.test.ts
+++ b/src/test/tcp/connect-error.test.ts
@@ -1,0 +1,89 @@
+import 'reflect-metadata'
+
+import { describeConnectError, withConnectReason } from '../../transport/tcp/connect-error'
+
+/**
+ * What an application is told when a connection fails.
+ *
+ * Node raises an AggregateError when the host resolved to several addresses and every
+ * attempt failed - the ordinary case, since 'localhost' is both ::1 and 127.0.0.1.  Its
+ * own message is empty and the detail is in errors[], so an initiator that reported
+ * e.message gave the caller an Error with nothing in it for the commonest failure
+ * there is: nobody listening on the other end.
+ */
+
+/**
+ * Reached through globalThis rather than named directly: AggregateError is ES2021 and
+ * this project compiles against an older lib, but it exists at run time on every node
+ * the engine supports.  So these are real AggregateErrors, not a hand made shape that
+ * might drift from what node actually raises.
+ */
+const AggregateErrorCtor: new (errors: Error[]) => Error = (globalThis as any).AggregateError
+
+function aggregate (messages: string[], code?: string): Error {
+  const e: any = new AggregateErrorCtor(messages.map(m => new Error(m)))
+  if (code) e.code = code
+  return e as Error
+}
+
+/** what net.createConnection actually raises for a refused dual stack host */
+function refusedAggregate (): Error {
+  return aggregate([
+    'connect ECONNREFUSED ::1:2349',
+    'connect ECONNREFUSED 127.0.0.1:2349'
+  ], 'ECONNREFUSED')
+}
+
+describe('describing a connect failure', () => {
+  test('a plain error keeps its own message', () => {
+    expect(describeConnectError(new Error('connect ETIMEDOUT 10.0.0.1:443')))
+      .toBe('connect ETIMEDOUT 10.0.0.1:443')
+  })
+
+  test('an aggregate reports what each address said', () => {
+    expect(describeConnectError(refusedAggregate()))
+      .toBe('connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349')
+  })
+
+  test('addresses failing the same way are not repeated', () => {
+    const e = aggregate([
+      'connect ECONNREFUSED 127.0.0.1:2349',
+      'connect ECONNREFUSED 127.0.0.1:2349'
+    ])
+    expect(describeConnectError(e)).toBe('connect ECONNREFUSED 127.0.0.1:2349')
+  })
+
+  test('falls back to the code when nothing carries a message', () => {
+    const e: any = new Error('')
+    e.code = 'ENOTFOUND'
+    expect(describeConnectError(e as Error)).toBe('ENOTFOUND')
+  })
+
+  test('an aggregate of empty errors still falls back to its own code', () => {
+    expect(describeConnectError(aggregate(['', ''], 'ECONNREFUSED'))).toBe('ECONNREFUSED')
+  })
+
+  test('survives being handed nothing', () => {
+    expect(describeConnectError(null)).toBe('unknown error')
+    expect(describeConnectError(undefined)).toBe('unknown error')
+  })
+})
+
+describe('the error an application catches', () => {
+  test('an empty message is filled in, and the error itself is kept', () => {
+    const original = refusedAggregate()
+    const returned = withConnectReason(original)
+
+    // the same object - code and errors are what a caller switches on, and wrapping
+    // it in a fresh Error to carry the text would have thrown both away
+    expect(returned).toBe(original)
+    expect(returned.message).toBe('connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349')
+    expect((returned as any).code).toBe('ECONNREFUSED')
+    expect((returned as any).errors).toHaveLength(2)
+  })
+
+  test('an error that already says something is left alone', () => {
+    const e = new Error('connect ETIMEDOUT 10.0.0.1:443')
+    expect(withConnectReason(e).message).toBe('connect ETIMEDOUT 10.0.0.1:443')
+  })
+})

--- a/src/transport/tcp/connect-error.ts
+++ b/src/transport/tcp/connect-error.ts
@@ -1,0 +1,56 @@
+/**
+ * A readable reason for a failed connection.
+ *
+ * Node raises an AggregateError when the host resolved to more than one address and
+ * every attempt failed.  That is not an edge case: 'localhost' is both ::1 and
+ * 127.0.0.1 on any modern machine, so it is what an ordinary refused connection looks
+ * like.  Its own message is empty and the detail sits in errors[], so reporting
+ * e.message alone said nothing at all about the commonest failure there is - an
+ * application catching a rejected connect saw an Error with no message.
+ *
+ * Falls back to the code (ECONNREFUSED, ENOTFOUND, ETIMEDOUT) when there is no
+ * message anywhere, which is still enough to act on.
+ */
+export function describeConnectError (e: unknown): string {
+  if (e == null) return 'unknown error'
+  const described = detail(e)
+  return described.length > 0 ? described : String(e)
+}
+
+/**
+ * The reason, or '' when this error carries none.
+ *
+ * Kept separate from the public function so a nested error with nothing to say
+ * contributes nothing, rather than a stringified 'Error' that would then look like a
+ * reason and stop the aggregate falling back to its own code.
+ */
+function detail (e: unknown): string {
+  if (e == null) return ''
+
+  const err = e as { message?: string, code?: string, errors?: unknown[] }
+
+  if (Array.isArray(err.errors) && err.errors.length > 0) {
+    // every address usually fails the same way - say it once rather than repeating
+    // 'connect ECONNREFUSED' for each family
+    const unique = Array.from(new Set(err.errors.map(detail).filter(m => m.length > 0)))
+    if (unique.length > 0) return unique.join('; ')
+  }
+
+  if (err.message) return err.message
+  if (err.code) return err.code
+  return ''
+}
+
+/**
+ * Give an error a message when it has none, keeping the object itself.
+ *
+ * Deliberately not a wrapper: `code` and `errors` are what a caller switches on, and
+ * building a fresh Error to hold the text would throw both away.  Returns the same
+ * error so it can be used inline.
+ */
+export function withConnectReason (e: Error): Error {
+  if (!e.message) {
+    e.message = describeConnectError(e)
+  }
+  return e
+}

--- a/src/transport/tcp/recovering-tcp-initiator.ts
+++ b/src/transport/tcp/recovering-tcp-initiator.ts
@@ -9,6 +9,7 @@ import { DITokens } from '../../runtime/di-tokens'
 import { ITcpTransportDescription } from './tcp-transport-description'
 import { IMsgApplication } from '../msg-application'
 import { FixEntity } from '../fix-entity'
+import { describeConnectError } from './connect-error'
 
 /*
    create one application session instance - and recover a lost transport.  Hence, the application
@@ -163,7 +164,7 @@ export class RecoveringTcpInitiator extends FixEntity {
       this.connect(this.connectTimeoutSecs).then(t => {
         this.logger.info(`new transport ${t.id}`)
       }).catch((e) => {
-        this.logger.info(`failed to re-connect ${e.message} - backoff for ${this.backoffFailConnectSecs}`)
+        this.logger.info(`failed to re-connect: ${describeConnectError(e)} - backoff for ${this.backoffFailConnectSecs}`)
         this.th = setTimeout(() => {
           this.logger.info('returning to recover()')
           setImmediate(() => {

--- a/src/transport/tcp/tcp-initiator.ts
+++ b/src/transport/tcp/tcp-initiator.ts
@@ -4,12 +4,12 @@ import { MsgTransport } from '../factory'
 import { IJsFixConfig, IJsFixLogger } from '../../config'
 import { TcpDuplex, FixDuplex } from '../duplex'
 
-import * as util from 'util'
 import { connect as tlsConnect, ConnectionOptions, TLSSocket } from 'tls'
 import { createConnection } from 'net'
 import Timeout = NodeJS.Timeout
 import { TlsOptionsFactory } from './tls-options-factory'
 import { describeConnectionOptions, describeNegotiated, describePeerCertificate } from './tls-diagnostics'
+import { describeConnectError, withConnectReason } from './connect-error'
 import { inject, injectable } from 'tsyringe'
 import { DITokens } from '../../runtime/di-tokens'
 import { ITcpTransportDescription } from './tcp-transport-description'
@@ -74,7 +74,7 @@ export class TcpInitiator extends FixInitiator {
               // connect() whose timeout expires before the first retry interval fires - the
               // default case, timeout and reconnectSeconds are both 5 - reported a generic
               // "timeout whilst connecting" and threw away the reason.  see #94.
-              this.logger.info(`first connect attempt failed: ${first.message}`)
+              this.logger.info(`first connect attempt failed: ${describeConnectError(first)}`)
               this.repeatConnect(timeoutSeconds, first)
                 .then((t: MsgTransport) => { resolve(t) })
                 .catch((e: Error) => { reject(e) })
@@ -212,7 +212,7 @@ export class TcpInitiator extends FixInitiator {
             resolve(t)
           }).catch((e: Error) => {
             lastError = e
-            this.logger.info(`${name}: retries ${retries} ${e.message}`)
+            this.logger.info(`${name}: retries ${retries} ${describeConnectError(e)}`)
           })
       }, reconnectSeconds * 1000)
       // a plain timer, not a promisified one: promisify(setTimeout) hands back no
@@ -223,7 +223,10 @@ export class TcpInitiator extends FixInitiator {
       this.timeoutTh = setTimeout(() => {
         this.clearTimer()
         this.state = InitiatorState.Stopped
-        const e = lastError ?? new Error(`${name}: timeout of ${timeoutSeconds} whilst connecting`)
+        // this error is what the application catches from run() - so give it a message
+        // it can print.  An AggregateError arrives with none at all, which meant a
+        // caller handling a failed connect had nothing to report but an empty string.
+        const e = withConnectReason(lastError ?? new Error(`${name}: timeout of ${timeoutSeconds} whilst connecting`))
         this.logger.warning(`${name}: giving up after ${timeoutSeconds}s and ${retries} retries, last error: ${e.message}`)
         reject(e)
       }, timeoutSeconds * 1000)


### PR DESCRIPTION
A refused connection reached the application as an `Error` with **no message**.

## What was happening

Node raises an `AggregateError` when the host resolved to more than one address and every attempt failed. That is not an edge case — `localhost` is both `::1` and `127.0.0.1` on any modern machine, so it is simply what an ordinary refused connection looks like:

```js
const s = createConnection({ host: 'localhost', port: 2349 })
s.on('error', e => {
  console.log(e.message)   // ''
  console.log(e.code)      // 'ECONNREFUSED'
  console.log(e.errors)    // [ 'connect ECONNREFUSED ::1:2349', 'connect ECONNREFUSED 127.0.0.1:2349' ]
})
```

`TcpInitiator` reported `e.message` throughout. So the commonest failure there is — nobody listening on the other end — logged this:

```
skeleton_client: retries 1
first connect attempt failed:
```

and rejected `run()` with an error whose `message` was `''`. An application catching a failed connect had nothing to print.

It also quietly undid #94, which was specifically about carrying the reason out of the first attempt instead of discarding it. The reason was being carried — it just had nowhere visible to go.

## The fix

`describeConnectError` walks `errors[]`, collapses a repeated reason to one copy (both families almost always fail identically), and falls back to the `code` when no message exists anywhere. Used by the first-attempt, retry, give-up and recovery logs.

The error handed back to the application gets its message filled in — **filled in rather than wrapped, deliberately**. `code` and `errors[]` are what callers switch on, and building a fresh `Error` to hold the text would throw both away. So it is the same object, with a message it previously lacked.

## What it looks like now

Verified end to end against jspf-demo through a local bundle, running its resilient client with nothing listening:

```
first connect attempt failed: connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349
skeleton_client: retries 1 connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349
skeleton_client: retries 2 connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349
skeleton_client: giving up after 6s and 2 retries, last error: connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349
[launcher] error: connect ECONNREFUSED ::1:2349; connect ECONNREFUSED 127.0.0.1:2349 : AggregateError [ECONNREFUSED]
```

That last line is the application's own catch around `run()` — the part that used to print nothing — with the aggregate's `code` and `errors[]` still intact behind it.

## Tests

`src/test/tcp/connect-error.test.ts`: a plain error keeps its message; an aggregate reports each address; identical reasons are not repeated; the code is used when nothing carries a message; an aggregate of empty errors still falls back to its own code; null and undefined are survivable; and the filled-in error is the *same object*, with `code` and `errors` preserved.

The aggregates in the test are real `AggregateError`s built through `globalThis` — it is ES2021 and this project compiles against an older lib, but it exists at run time on every supported node, so the tests match what node actually raises rather than a hand-made shape that could drift.

Full suite green — 672 tests, 66 suites. Lint clean.

Suggested as a patch release: it changes no API, only what an error says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
