### PR TITLE
feat(config): carry structured fields on the logger 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ import {
 
 A minimal session subclasses `AsciiSession` and implements two callbacks: `onReady` (connection up, logon confirmed) and `onApplicationMsg` (a non-session message arrived).
 
+The second argument to `logger()` binds structured fields to every line that logger writes, and `info`/`warning`/`debug`/`error` each take an optional bag of per-call fields. Both are optional and additive — the default console format renders exactly as it always has, and installing `WinstonLogger.ecsOptions()` instead emits one ECS-style JSON object per line for Filebeat. See [docs/instrumentation.md](docs/instrumentation.md).
+
 ```typescript
 class TradeCaptureClient extends AsciiSession {
   constructor (public readonly config: IJsFixConfig) {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config.description.application.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureClient`)
+    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureClient`,
+      { component: 'TradeCaptureClient', app: this.me })
   }
 
   protected onReady (view: MsgView): void {

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -135,31 +135,160 @@ someone's Prometheus falls over.
 
 ## Structured logging
 
-Filebeat wants fields, not prose, and today `IJsFixLogger` cannot carry any:
+**This lands first, on its own.** Not because it is smaller — because it delivers the
+whole Elastic story by itself, and because the pass that adds fields is the pass that
+locates every future counter site.
+
+Worth separating two consumers that want opposite things:
+
+- **Filebeat and Elastic are push.** The engine writes JSON lines, Filebeat harvests,
+  Kibana does the drill-down. No server in the engine at all.
+- **A live diagnostics endpoint is pull.** For when there is no Elastic stack, or when
+  someone wants the state of a process now rather than after a harvest cycle.
+
+The click-through-and-drill-down picture is entirely the first of those. That makes the
+web server in [packaging](#packaging-boundary) an independent, later, optional thing
+rather than a prerequisite.
+
+### The leverage is bound context, not the call sites
+
+The engine has **307 logger call sites** (239 `info`, 39 `warning`, 15 `error`, 14 `debug`)
+but only **29 places a logger is constructed**. And the identity is already at those 29:
 
 ```ts
+this.sessionLogger = config.logFactory.logger(`${this.me}:${peerCompId}:FixSession`)
+```
+
+That is the session identity, built once, and completely opaque downstream — the "regex
+over English" problem, except it is not even English, it is punctuation. So the first move
+is not widening 307 call sites, it is widening the 29. Bound context makes every one of the
+307 filterable without touching any of them.
+
+Per-call fields then matter only where a line carries a *value* worth aggregating —
+`msgType`, seq nums, byte counts, state transitions, gap ranges. Perhaps 25 lines, chosen
+deliberately. They are the same chokepoints [layer 1](#layer-1--chokepoints) lists, which
+is why doing this first leaves the metrics work half-located.
+
+### The interface
+
+```ts
+export type JsFixLogFields = Record<string, unknown>
+
 export interface IJsFixLogger {
-  info: (message: string) => void
-  warning: (message: string) => void
-  debug: (message: string) => void
-  error: (e: Error) => void
+  info: (message: string, fields?: JsFixLogFields) => void
+  warning: (message: string, fields?: JsFixLogFields) => void
+  debug: (message: string, fields?: JsFixLogFields) => void
+  error: (e: Error, fields?: JsFixLogFields) => void
+}
+
+export abstract class JsFixLoggerFactory {
+  public abstract logger (type: string, context?: JsFixLogFields): IJsFixLogger
 }
 ```
 
-Every line arrives pre-formatted, so nothing downstream can filter by `sessionId` or
-`msgType` without regex over English. Making the engine log-shippable means widening
-this — an optional second argument keeps every existing implementation compiling:
+Non-breaking, and worth being precise about why: TypeScript lets an implementation declare
+*fewer* parameters than the interface, so a client's existing `info(message: string)` still
+satisfies it, and their `JsFixLoggerFactory` subclass keeps working while ignoring the new
+argument. Callers are unaffected either way.
 
-```ts
-info: (message: string, fields?: Record<string, unknown>) => void
+`error` gains fields as well as the others. It currently takes only an `Error` — no
+message, no context — and those 15 sites are the ones most wanted at 3am.
+
+**Bound context, not a `child()` logger.** It fits the 29 construction sites, and it ports:
+a `child()` would put an object lifecycle in the contract. See
+[porting](#porting-to-cspurefix).
+
+### Not breaking the existing line
+
+The engine has been live for years; people have grep and scrapers built on the current
+output. That output must not move.
+
+```
+2026-08-16T14:14:56.102Z [skeleton_server:skeleton-client:FixSession] info: peer sent ...
 ```
 
-winston is already the default factory and emits JSON without further work, so most of
-the cost is deciding which fields belong on which line, and doing it consistently enough
-to be worth filtering on.
+The shipped format names exactly four fields:
 
-This is separable from metrics and could land first — it is smaller, and it is the half
-that helps someone debugging a live session at 3am.
+```ts
+printf(info => `${info.timestamp} [${info.type}] ${info.level}: ${info.message}`)
+```
+
+So as long as context and per-call fields go into the winston info object as **separate
+keys**, that printf never sees them. Verified: the same call with and without the new keys
+renders byte-identically apart from the millisecond.
+
+Three rules follow, and each has bitten already:
+
+1. **`type` stays verbatim at all 29 sites.** It cannot be composed from the fields — the
+   sites have no single rule between them (bare literals `'acceptor'`, one-part
+   `` `${this.me}` ``, two-part `` `${name}:TcpInitiator` ``, three-part
+   `` `${me}:${peer}:FixSession` ``, and one dotted `` `${type}.${t}` ``). Deriving it
+   means per-site rules, which is the same edit with more ways to get a string subtly
+   wrong. The resulting duplication between `type` and the fields is the price of not
+   breaking grep, and it is cheap. In a JSON rendering `type` is simply dropped, because
+   `component` and `app` carry it properly.
+2. **Fields are namespaced, never spread.** They travel under `context` and `fields` keys
+   and the *formatter* decides how to flatten. Spreading at the top level lets a caller's
+   `{ message: … }` clobber the real message. It also keeps the contract
+   transport-agnostic, which is what makes it port.
+3. **A winston format function must mutate `info`, not return a new object.** Returning a
+   fresh object drops `Symbol.for('level')` and winston discards the record silently — no
+   output, no error. Found the hard way while proving the above.
+
+### The default does not change
+
+`WinstonLogger.consoleOptions()` does **not** emit JSON today — it is a `printf` rendering
+prose, so "winston gives JSON for free" is not true as things stand. JSON arrives as a new
+opt-in `ecsOptions()`, and the console default stays exactly as it is. Not only for this
+release: changing a default log format is a major-version event at best and probably never
+worth it.
+
+`WinstonLogger.plain()` is message-only and used for FIX wire logs. That is a replay
+artifact, not structured-log material, and stays as it is.
+
+Two things make "same output after upgrade" a guarantee rather than a promise:
+
+- **A golden-output test** rendering lines through `consoleOptions()` with and without
+  context and fields, asserting the strings are identical. Anyone later improving
+  `appFormat` then fails a test instead of breaking a customer's scraper.
+- **The fields commit rewords no messages.** Mixing the two makes a before/after log diff
+  unreadable. Keep them separate so the diff at a given level is genuinely empty.
+
+### Field names
+
+ECS names where they exist — `service.name`, `log.level`, `error.message`,
+`error.stack_trace` — and everything engine-specific under `fix.*`. Context keys are plain
+words; the formatter applies the prefix.
+
+| context key | rendered | meaning |
+| --- | --- | --- |
+| `component` | `fix.component` | the class, e.g. `FixSession`, `TcpAcceptor` |
+| `app` | `fix.app` | application name from the session description |
+| `peer` | `fix.peer` | counterparty comp id, once known |
+| `role` | `fix.role` | `initiator` or `acceptor` |
+
+This is the metric prefix decision applied to logs: `fix.msg_type` in a log line,
+`fix_messages_total{msg_type}` in a metric — same words, each in its own convention's
+punctuation, so one dashboard serves both engines.
+
+`fix.session` in the canonical `BeginString-Sender-Target` form is deliberately **not** in
+the table above. A wildcard acceptor does not know its peer until bind time, so the field
+would be absent or wrong on exactly the sessions that need it most. It arrives with the
+metrics work, where `SessionId` is properly to hand — `AsciiSession` already rebuilds its
+logger at bind for this reason, so the seam is there.
+
+Rendered, one call site gives either:
+
+```
+2026-08-16T14:17:31.864Z [skeleton_server:skeleton-client:FixSession] info: peer sent ResetSeqNumFlag=Y with seqNum=1, weAlsoReset=true
+```
+
+```json
+{"@timestamp":"2026-08-16T14:17:59.278Z","log.level":"info","service.name":"jspurefix",
+ "message":"peer sent ResetSeqNumFlag=Y with seqNum=1, weAlsoReset=true",
+ "fix.component":"FixSession","fix.app":"skeleton_server","fix.peer":"skeleton-client",
+ "fix.reset_seq_num_flag":true,"fix.seq_num":1,"fix.we_also_reset":true}
+```
 
 ## Packaging boundary
 
@@ -188,6 +317,13 @@ differ, and the spec should not pretend otherwise:
   hold two panels.
 - **Sink interface.** A plain interface with a no-op implementation in both; no
   `EventEmitter` in the contract, since that would not port.
+- **Logging shape.** .NET expresses this differently: bound context is `BeginScope`, and
+  per-call fields come from message templates (`"session {SessionId} up"`) rather than a
+  separate object. Both can emit identical JSON, but they are not the same API. The
+  portable contract is *bound fields plus per-call fields*, and each engine renders it
+  idiomatically — forcing the TypeScript shape onto `Microsoft.Extensions.Logging` would
+  produce something unidiomatic that nobody on that side would want to use. What must
+  match is the emitted field names, not the call signature.
 - **Histograms.** Prometheus histograms need fixed buckets. Agree the bucket boundaries
   here so latency panels are comparable between engines rather than merely similar.
 
@@ -195,8 +331,16 @@ differ, and the spec should not pretend otherwise:
 
 1. Per-session snapshot with registry rollup, or one flat structure?
 2. Is `session` a metric label, and if so how is cardinality bounded?
-3. Does structured logging land first, on its own?
+3. ~~Does structured logging land first, on its own?~~ **Yes** — see
+   [structured logging](#structured-logging). Bound context on the factory rather than a
+   `child()` logger, `type` kept verbatim, console format unchanged.
 4. Histogram buckets for parse and encode duration.
-5. Does the diagnostics endpoint live in this repository at all, or its own package?
+5. Does the diagnostics endpoint live in this repository at all, or its own package? It
+   needs no framework — `node:http` and about a hundred lines — which is what stops
+   `express` being reached for a second time.
 6. Sampling: are parse timings measured on every message, or 1-in-N once throughput is
    high enough for the measurement itself to show up in the measurement?
+7. Does the engine own the ECS field names, or hand people a formatter to remap? Someone
+   with an existing Splunk convention will want the latter.
+8. When per-call fields land, do the ~25 chosen lines also get their message text left
+   alone permanently, so the prose and the fields never drift apart?

--- a/src/buffer/fixml/fixml-parser.ts
+++ b/src/buffer/fixml/fixml-parser.ts
@@ -37,7 +37,7 @@ export class FiXmlParser extends MsgParser {
     this.definitions = this.config.definitions
     const description = config.description
     const me = description?.application?.name
-    this.logger = config.logFactory.logger(`${me}:FiXmlParser`)
+    this.logger = config.logFactory.logger(`${me}:FiXmlParser`, { component: 'FixmlParser', app: me })
     this.saxStream = require('sax').createStream(true, {})
     this.locations = new Tags(maxMessageLocations)
     this.logger.info('subscribe to stream')

--- a/src/config/empty-log-factory.ts
+++ b/src/config/empty-log-factory.ts
@@ -1,8 +1,8 @@
-import { EmptyLogger, IJsFixLogger } from './js-fix-logger'
+import { EmptyLogger, IJsFixLogger, JsFixLogFields } from './js-fix-logger'
 import { JsFixLoggerFactory } from './js-fix-logger-factory'
 
 export class EmptyLogFactory extends JsFixLoggerFactory {
-  public logger (type: string): IJsFixLogger {
+  public logger (type: string, _?: JsFixLogFields): IJsFixLogger {
     return new EmptyLogger(type)
   }
 

--- a/src/config/get-js-fx-logger.ts
+++ b/src/config/get-js-fx-logger.ts
@@ -1,3 +1,3 @@
-import { IJsFixLogger } from './js-fix-logger'
+import { IJsFixLogger, JsFixLogFields } from './js-fix-logger'
 
-export type GetJsFixLogger = (type: string) => IJsFixLogger
+export type GetJsFixLogger = (type: string, context?: JsFixLogFields) => IJsFixLogger

--- a/src/config/js-fix-logger-factory.ts
+++ b/src/config/js-fix-logger-factory.ts
@@ -1,6 +1,12 @@
-import { IJsFixLogger } from './js-fix-logger'
+import { IJsFixLogger, JsFixLogFields } from './js-fix-logger'
 
 export abstract class JsFixLoggerFactory {
-  public abstract logger (type: string): IJsFixLogger
+  /**
+   * @param type the legacy display name, e.g. 'me:peer:FixSession'.  it is what the
+   * console format renders between brackets, so it is passed verbatim and unchanged
+   * @param context fields bound to every line this logger writes.  an implementation
+   * written before this argument existed keeps compiling and simply ignores it
+   */
+  public abstract logger (type: string, context?: JsFixLogFields): IJsFixLogger
   public abstract plain (fileName: string, maxSize?: number): IJsFixLogger
 }

--- a/src/config/js-fix-logger.ts
+++ b/src/config/js-fix-logger.ts
@@ -1,27 +1,42 @@
+/**
+ * structured fields carried alongside a log message.
+ *
+ * two kinds travel through the same shape.  *context* is bound once when a logger is made
+ * and repeats on every line it writes - the component, the application, the counterparty.
+ * *fields* are supplied per call and carry a value worth aggregating on - a msgType, a
+ * sequence number, a byte count.
+ *
+ * they are deliberately kept as a bag rather than spread into the log record, so a caller
+ * passing { message: ... } cannot clobber the real message, and so the choice of how to
+ * render them belongs to the formatter rather than the engine.  see
+ * docs/instrumentation.md.
+ */
+export type JsFixLogFields = Record<string, unknown>
+
 export interface IJsFixLogger {
-  info: (message: string) => void
-  warning: (message: string) => void
-  debug: (message: string) => void
-  error: (e: Error) => void
+  info: (message: string, fields?: JsFixLogFields) => void
+  warning: (message: string, fields?: JsFixLogFields) => void
+  debug: (message: string, fields?: JsFixLogFields) => void
+  error: (e: Error, fields?: JsFixLogFields) => void
 }
 
 export class EmptyLogger implements IJsFixLogger {
   constructor (public readonly type: string = '') {
   }
 
-  public info (_: string): void {
+  public info (_: string, __?: JsFixLogFields): void {
     // nothing
   }
 
-  public warning (_: string): void {
+  public warning (_: string, __?: JsFixLogFields): void {
     // nothing
   }
 
-  public debug (_: string): void {
+  public debug (_: string, __?: JsFixLogFields): void {
     // nothing
   }
 
-  public error (_: Error): void {
+  public error (_: Error, __?: JsFixLogFields): void {
     // nothing
   }
 }

--- a/src/config/js-fix-winston-log-factory.ts
+++ b/src/config/js-fix-winston-log-factory.ts
@@ -1,4 +1,4 @@
-import { IJsFixLogger } from './js-fix-logger'
+import { IJsFixLogger, JsFixLogFields } from './js-fix-logger'
 import { WinstonLogger } from './winston-logger'
 import { JsFixLoggerFactory } from './js-fix-logger-factory'
 
@@ -10,8 +10,8 @@ export class JsFixWinstonLogFactory extends JsFixLoggerFactory {
     this.wl = new WinstonLogger(options)
   }
 
-  public logger (type: string): IJsFixLogger {
-    return this.wl.make(type)
+  public logger (type: string, context?: JsFixLogFields): IJsFixLogger {
+    return this.wl.make(type, context)
   }
 
   public plain (fileName: string, maxSize?: number): IJsFixLogger {

--- a/src/config/winston-logger.ts
+++ b/src/config/winston-logger.ts
@@ -1,15 +1,53 @@
-import { IJsFixLogger } from './js-fix-logger'
+import { IJsFixLogger, JsFixLogFields } from './js-fix-logger'
 import { Logger } from 'winston'
 const { createLogger, format, transports } = require('winston')
 const { combine, timestamp, printf } = format
 
 export class WinstonLogger {
+  /**
+   * the format this engine has emitted since it shipped.  it names exactly four fields, so
+   * the context and fields bags added later are invisible to it and the rendered line is
+   * unchanged - which is the whole reason they travel as separate keys.  covered by a
+   * golden output test; do not widen it.
+   */
   public static readonly appFormat = printf((info: any) => {
     return `${info.timestamp} [${info.type}] ${info.level}: ${info.message}`
   })
 
   public static readonly plainFormat = printf((info: any) => {
     return `${info.message}`
+  })
+
+  /**
+   * flattens the context and fields bags to ECS style names for Filebeat and friends.
+   *
+   * this MUST mutate info rather than return a fresh object - a new object loses
+   * Symbol.for('level') and winston then discards the record with no output and no error.
+   */
+  public static readonly ecsFormat = format((info: any) => {
+    const context = info.context ?? {}
+    const fields = info.fields ?? {}
+    const err = info.err
+    delete info.context
+    delete info.fields
+    delete info.err
+    // the legacy display name is redundant once component and app are real fields
+    delete info.type
+    info['@timestamp'] = info.timestamp
+    info['log.level'] = info.level
+    info['service.name'] = 'jspurefix'
+    delete info.timestamp
+    if (err) {
+      info['error.message'] = err.message
+      info['error.stack_trace'] = err.stack
+    }
+    for (const key of Object.keys(context)) {
+      info[`fix.${key}`] = context[key]
+    }
+    for (const key of Object.keys(fields)) {
+      info[`fix.${key}`] = fields[key]
+    }
+    return info
   })
 
   private readonly appLogger: Logger
@@ -29,6 +67,32 @@ export class WinstonLogger {
         new transports.Console()
       ]
     }
+  }
+
+  /**
+   * one JSON object per line, ECS style names, ready to be harvested.  opt in - the
+   * console default is deliberately left alone so an upgrade does not move anyone's logs.
+   */
+  public static ecsOptions (level: string = 'debug'): any {
+    return {
+      format: combine(
+        timestamp(),
+        WinstonLogger.ecsFormat(),
+        format.json()
+      ),
+      level,
+      transports: [
+        new transports.Console()
+      ]
+    }
+  }
+
+  public static ecsFileOptions (fileName: string, level: string = 'debug', maxSize: number = 50 * 1024 * 1024): any {
+    return WinstonLogger.fileOptions(fileName, level, maxSize, combine(
+      timestamp(),
+      WinstonLogger.ecsFormat(),
+      format.json()
+    ))
   }
 
   public static fileOptions (fileName: string, level: string = 'debug', maxSize: number = 50 * 1024 * 1024, format: any = combine(
@@ -82,31 +146,42 @@ export class WinstonLogger {
     } as IJsFixLogger
   }
 
-  public make (type: string): IJsFixLogger {
+  public make (type: string, context?: JsFixLogFields): IJsFixLogger {
     const logger = this.appLogger
     return {
-      info: function (msg: string): void {
+      info: function (msg: string, fields?: JsFixLogFields): void {
         logger.info({
           type,
-          message: msg
+          message: msg,
+          context,
+          fields
         })
       },
-      debug: function (msg: string): void {
+      debug: function (msg: string, fields?: JsFixLogFields): void {
         logger.debug({
           type,
-          message: msg
+          message: msg,
+          context,
+          fields
         })
       },
-      warning: function (msg: string): void {
+      warning: function (msg: string, fields?: JsFixLogFields): void {
         logger.warn({
           type,
-          message: msg
+          message: msg,
+          context,
+          fields
         })
       },
-      error: function (e: Error): void {
+      error: function (e: Error, fields?: JsFixLogFields): void {
         logger.error({
           type,
-          message: `${e.message} : ${e.stack}`
+          // composed exactly as it always has been, so the console line does not move.
+          // the ecs format lifts error.message and error.stack_trace off err instead
+          message: `${e.message} : ${e.stack}`,
+          err: e,
+          context,
+          fields
         })
       }
     }

--- a/src/runtime/make-config.ts
+++ b/src/runtime/make-config.ts
@@ -25,7 +25,7 @@ export class RuntimeFactory {
         if (!type) reject(new Error('no application type in application object'))
         this.definitionFactory.getDefinitions(path,
           (t: string) => {
-            return this.logFactory.logger(`${type}.${t}`)
+            return this.logFactory.logger(`${type}.${t}`, { component: t, role: type })
           }).then((definitions: FixDefinitions) => {
           const config = new JsFixConfig(this.msgFactory, definitions, description, AsciiChars.Soh, this.logFactory)
           resolve(config)

--- a/src/runtime/session-launcher.ts
+++ b/src/runtime/session-launcher.ts
@@ -19,7 +19,7 @@ export abstract class SessionLauncher {
     acceptorConfig: string | ISessionDescription | null = null,
     private readonly loggerFactory: JsFixLoggerFactory = defaultLoggerFactory
   ) {
-    this.logger = this.loggerFactory.logger('launcher')
+    this.logger = this.loggerFactory.logger('launcher', { component: 'SessionLauncher' })
     this.initiatorConfig = initiatorConfig ? this.loadConfig(initiatorConfig) : null
     this.acceptorConfig = acceptorConfig ? this.loadConfig(acceptorConfig) : null
   }

--- a/src/sample/http/oms/http-client.ts
+++ b/src/sample/http/oms/http-client.ts
@@ -16,7 +16,7 @@ export class HttpClient extends FixmlSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}`)
+    this.logger = config.logFactory.logger(`${this.me}`, { component: 'HttpClient', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, view: MsgView): void {

--- a/src/sample/http/oms/http-server.ts
+++ b/src/sample/http/oms/http-server.ts
@@ -16,7 +16,7 @@ export class HttpServer extends FixmlSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}`)
+    this.logger = config.logFactory.logger(`${this.me}`, { component: 'HttpServer', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, view: MsgView): void {

--- a/src/sample/tcp/qf-md/md-client.ts
+++ b/src/sample/tcp/qf-md/md-client.ts
@@ -16,7 +16,7 @@ export class MDClient extends AsciiSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}:MDClient`)
+    this.logger = config.logFactory.logger(`${this.me}:MDClient`, { component: 'MDClient', app: this.me })
   }
 
   protected onApplicationMsg (_: string, view: MsgView): void {

--- a/src/sample/tcp/qf-md/md-server.ts
+++ b/src/sample/tcp/qf-md/md-server.ts
@@ -16,7 +16,7 @@ export class MDServer extends AsciiSession {
   constructor (@inject('IJsFixConfig') public readonly config: IJsFixConfig) {
     super(config)
     this.logReceivedMsgs = true
-    this.logger = config.logFactory.logger(`${this.me}:MDServer`)
+    this.logger = config.logFactory.logger(`${this.me}:MDServer`, { component: 'MDServer', app: this.me })
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
   }
 

--- a/src/sample/tcp/recovering-skeleton/respawn-acceptor.ts
+++ b/src/sample/tcp/recovering-skeleton/respawn-acceptor.ts
@@ -13,7 +13,8 @@ export class RespawnAcceptor extends FixEntity {
 
   constructor (@inject('IJsFixConfig') public readonly config: IJsFixConfig) {
     super(config)
-    this.logger = config.logFactory.logger('RespawnAcceptor')
+    this.logger = config.logFactory.logger('RespawnAcceptor',
+      { component: 'RespawnAcceptor', role: 'acceptor' })
   }
 
   // if acceptor errors e.g. via a forced connection drop, then respawn

--- a/src/sample/tcp/recovering-skeleton/skeleton-client.ts
+++ b/src/sample/tcp/recovering-skeleton/skeleton-client.ts
@@ -13,7 +13,7 @@ export class SkeletonClient extends AsciiSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}`)
+    this.logger = config.logFactory.logger(`${this.me}`, { component: 'SkeletonClient', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, view: MsgView): void {

--- a/src/sample/tcp/recovering-skeleton/skeleton-server.ts
+++ b/src/sample/tcp/recovering-skeleton/skeleton-server.ts
@@ -13,7 +13,7 @@ export class SkeletonServer extends AsciiSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}`)
+    this.logger = config.logFactory.logger(`${this.me}`, { component: 'SkeletonServer', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, _: MsgView): void {

--- a/src/sample/tcp/skeleton/skeleton-session.ts
+++ b/src/sample/tcp/skeleton/skeleton-session.ts
@@ -17,7 +17,7 @@ export class SkeletonSession extends AsciiSession {
     super(config)
     this.logReceivedMsgs = true
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}`)
+    this.logger = config.logFactory.logger(`${this.me}`, { component: 'SkeletonSession', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, view: MsgView): void {

--- a/src/sample/tcp/trade-capture/trade-capture-client.ts
+++ b/src/sample/tcp/trade-capture/trade-capture-client.ts
@@ -18,7 +18,8 @@ export class TradeCaptureClient extends AsciiSession {
     this.logReceivedMsgs = true
     this.reports = new Map<string, ITradeCaptureReport>()
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
-    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureClient`)
+    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureClient`,
+      { component: 'TradeCaptureClient', app: this.me })
   }
 
   protected onApplicationMsg (msgType: string, view: MsgView): void {

--- a/src/sample/tcp/trade-capture/trade-capture-server.ts
+++ b/src/sample/tcp/trade-capture/trade-capture-server.ts
@@ -18,7 +18,8 @@ export class TradeCaptureServer extends AsciiSession {
   constructor (public readonly config: IJsFixConfig) {
     super(config)
     this.logReceivedMsgs = true
-    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureServer`)
+    this.logger = config.logFactory.logger(`${this.me}:TradeCaptureServer`,
+      { component: 'TradeCaptureServer', app: this.me })
     this.fixLog = config.logFactory.plain(`jsfix.${config?.description?.application?.name}.txt`)
   }
 

--- a/src/store/fix-msg-memory-store.ts
+++ b/src/store/fix-msg-memory-store.ts
@@ -20,7 +20,8 @@ export class FixMsgMemoryStore implements IFixMsgStore {
   ]
 
   public constructor (public readonly id: string, public readonly config: IJsFixConfig) {
-    this.logger = config.logFactory.logger(`${this.id}:FixMsgMemoryStore`)
+    this.logger = config.logFactory.logger(`${this.id}:FixMsgMemoryStore`,
+      { component: 'FixMsgMemoryStore', store: this.id })
     this.setExcMsgType([])
   }
 

--- a/src/test/config/structured-logging.test.ts
+++ b/src/test/config/structured-logging.test.ts
@@ -1,0 +1,147 @@
+import 'reflect-metadata'
+
+import { EmptyLogFactory, IJsFixLogger, JsFixLogFields, JsFixLoggerFactory, WinstonLogger } from '../../config'
+
+/**
+ * The engine has been live for years and people have grep and scrapers built on the
+ * console format.  Structured logging is additive: context and per-call fields travel as
+ * separate keys on the log record, and the shipped format names only four of them, so the
+ * rendered line does not move.
+ *
+ * These tests exist so that anyone later widening WinstonLogger.appFormat fails here
+ * rather than in a customer's log pipeline.  See docs/instrumentation.md.
+ */
+
+/**
+ * captures what a winston transport would write, by rendering through the same format
+ * pipeline the shipped options build
+ */
+function render (options: any, emit: (logger: IJsFixLogger) => void, type: string, context?: JsFixLogFields): string[] {
+  const lines: string[] = []
+  const captured = {
+    ...options,
+    transports: [
+      new (require('winston-transport'))({
+        log (info: any, next: () => void) {
+          lines.push(info[Symbol.for('message')])
+          next()
+        }
+      })
+    ]
+  }
+  emit(new WinstonLogger(captured).make(type, context))
+  return lines
+}
+
+const TYPE = 'skeleton_server:skeleton-client:FixSession'
+const MESSAGE = 'peer sent ResetSeqNumFlag=Y with seqNum=1, weAlsoReset=true'
+const CONTEXT: JsFixLogFields = { component: 'FixSession', app: 'skeleton_server', peer: 'skeleton-client' }
+const FIELDS: JsFixLogFields = { reset_seq_num_flag: true, seq_num: 1, we_also_reset: true }
+
+/**
+ * the timestamp is the only thing that legitimately differs between two runs
+ */
+function withoutTimestamp (line: string): string {
+  return line.replace(/^\S+ /, '')
+}
+
+describe('console format is unmoved by structured logging', () => {
+  test('a line with context and fields renders identically to one without', () => {
+    const bare = render(WinstonLogger.consoleOptions(), l => { l.info(MESSAGE) }, TYPE)
+    const rich = render(WinstonLogger.consoleOptions(), l => { l.info(MESSAGE, FIELDS) }, TYPE, CONTEXT)
+    expect(rich.length).toEqual(1)
+    expect(withoutTimestamp(rich[0])).toEqual(withoutTimestamp(bare[0]))
+  })
+
+  test('the rendered shape is the one shipped since the engine went live', () => {
+    const lines = render(WinstonLogger.consoleOptions(), l => { l.info(MESSAGE, FIELDS) }, TYPE, CONTEXT)
+    expect(withoutTimestamp(lines[0])).toEqual(`[${TYPE}] info: ${MESSAGE}`)
+  })
+
+  test.each([
+    ['warning', (l: IJsFixLogger) => { l.warning(MESSAGE, FIELDS) }, 'warn'],
+    ['debug', (l: IJsFixLogger) => { l.debug(MESSAGE, FIELDS) }, 'debug']
+  ])('%s keeps its level and layout', (_name, emit, level) => {
+    const lines = render(WinstonLogger.consoleOptions(), emit, TYPE, CONTEXT)
+    expect(withoutTimestamp(lines[0])).toEqual(`[${TYPE}] ${level}: ${MESSAGE}`)
+  })
+
+  /**
+   * error composes message from the Error exactly as it always has - the ecs format lifts
+   * error.message and error.stack_trace off a separate key instead
+   */
+  test('error still renders message and stack into the one line', () => {
+    const e = new Error('boom')
+    const lines = render(WinstonLogger.consoleOptions(), l => { l.error(e, FIELDS) }, TYPE, CONTEXT)
+    expect(withoutTimestamp(lines[0])).toEqual(`[${TYPE}] error: ${e.message} : ${e.stack ?? ''}`)
+  })
+})
+
+describe('ecs format carries the structure', () => {
+  function parse (line: string): any {
+    return JSON.parse(line)
+  }
+
+  test('context and fields are flattened under the fix namespace', () => {
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.info(MESSAGE, FIELDS) }, TYPE, CONTEXT)
+    const o = parse(lines[0])
+    expect(o['fix.component']).toEqual('FixSession')
+    expect(o['fix.app']).toEqual('skeleton_server')
+    expect(o['fix.peer']).toEqual('skeleton-client')
+    expect(o['fix.seq_num']).toEqual(1)
+    expect(o['fix.we_also_reset']).toEqual(true)
+    expect(o.message).toEqual(MESSAGE)
+    expect(o['log.level']).toEqual('info')
+    expect(o['service.name']).toEqual('jspurefix')
+    expect(o['@timestamp']).toBeTruthy()
+  })
+
+  /**
+   * the legacy display name is redundant once component and app are real fields, and a
+   * JSON consumer is by definition new, so nothing is broken by dropping it here
+   */
+  test('the legacy type is not emitted', () => {
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.info(MESSAGE) }, TYPE, CONTEXT)
+    expect(parse(lines[0]).type).toBeUndefined()
+  })
+
+  test('an error carries stack trace as its own field', () => {
+    const e = new Error('boom')
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.error(e) }, TYPE, CONTEXT)
+    const o = parse(lines[0])
+    expect(o['error.message']).toEqual('boom')
+    expect(o['error.stack_trace']).toContain('boom')
+  })
+
+  /**
+   * a caller cannot clobber the record by naming a reserved key, because the bags are
+   * nested rather than spread
+   */
+  test('a field named message does not displace the real message', () => {
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.info(MESSAGE, { message: 'hijacked' }) }, TYPE, CONTEXT)
+    const o = parse(lines[0])
+    expect(o.message).toEqual(MESSAGE)
+    expect(o['fix.message']).toEqual('hijacked')
+  })
+})
+
+describe('the widened interface stays compatible', () => {
+  /**
+   * a factory written before context existed declares one parameter.  TypeScript allows an
+   * implementation to take fewer arguments than its interface, so this still satisfies
+   * JsFixLoggerFactory and simply ignores what it does not know about
+   */
+  test('a one argument logger factory still satisfies the abstract class', () => {
+    class LegacyFactory extends EmptyLogFactory {
+      public override logger (type: string): IJsFixLogger {
+        return super.logger(type)
+      }
+    }
+    // the engine only ever holds the abstract type, and that is where the widened call
+    // has to typecheck
+    const f: JsFixLoggerFactory = new LegacyFactory()
+    const logger = f.logger('anything', { component: 'ignored' })
+    expect(logger).toBeTruthy()
+    expect(() => { logger.info('still works', { seq_num: 1 }) }).not.toThrow()
+  })
+})

--- a/src/transport/ascii/ascii-msg-transmitter.ts
+++ b/src/transport/ascii/ascii-msg-transmitter.ts
@@ -39,7 +39,8 @@ export class AsciiMsgTransmitter extends MsgTransmitter {
    */
   private reportUnknownFields (config: IJsFixConfig): void {
     const name = config.description.application?.name ?? 'na'
-    const logger = config.logFactory.logger(`${name}:encoder`)
+    const logger = config.logFactory.logger(`${name}:encoder`,
+      { component: 'AsciiMsgTransmitter', app: name })
     const reported = new Set<string>()
     this.encoder.onUnknownField = (fieldName: string, setName: string) => {
       const key = `${setName}.${fieldName}`

--- a/src/transport/ascii/ascii-session.ts
+++ b/src/transport/ascii/ascii-session.ts
@@ -662,7 +662,8 @@ export abstract class AsciiSession extends FixSession {
 
     // every session on a wildcard listener shared one logger name until now, which
     // makes a multi-client server log impossible to follow
-    this.sessionLogger = this.config.logFactory.logger(`${this.me}:${peerCompId}:FixSession`)
+    this.sessionLogger = this.config.logFactory.logger(`${this.me}:${peerCompId}:FixSession`,
+      { component: 'FixSession', app: this.me, peer: peerCompId })
 
     this.sessionId = new SessionId(
       this.config.description.BeginString,

--- a/src/transport/http/http-acceptor-listener.ts
+++ b/src/transport/http/http-acceptor-listener.ts
@@ -15,7 +15,8 @@ export class HttpAcceptorListener extends FixEntity {
 
   async start (): Promise<any> {
     return new Promise<any>(async (resolve, reject) => {
-      const logger = this.config.logFactory.logger('acceptor')
+      const logger = this.config.logFactory.logger('acceptor',
+        { component: 'HttpAcceptorListener', role: 'acceptor' })
       const sessionContainer = this.config.sessionContainer
       if (!sessionContainer.isRegistered(DITokens.FixSession)) {
         reject(new Error(`application must register a DI token '${DITokens.FixSession}' - see src/sample`))

--- a/src/transport/http/http-acceptor.ts
+++ b/src/transport/http/http-acceptor.ts
@@ -22,7 +22,8 @@ export class HttpAcceptor extends FixAcceptor {
 
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig) {
     super(config?.description?.application ?? null)
-    this.logger = config.logFactory.logger(`${config?.description?.application?.name}:HttpAcceptor`)
+    this.logger = config.logFactory.logger(`${config?.description?.application?.name}:HttpAcceptor`,
+      { component: 'HttpAcceptor', app: config?.description?.application?.name, role: 'acceptor' })
     this.logger.info('creating http server')
     this.router = express.Router()
     this.router.use(bodyParser.json())

--- a/src/transport/http/http-initiator.ts
+++ b/src/transport/http/http-initiator.ts
@@ -11,7 +11,8 @@ export class HttpInitiator extends FixEntity {
   logger: IJsFixLogger
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig) {
     super(config)
-    this.logger = config.logFactory.logger('initiator')
+    this.logger = config.logFactory.logger('initiator',
+      { component: 'HttpInitiator', role: 'initiator' })
   }
 
   async start (): Promise<any> {

--- a/src/transport/http/http-json-sample-adapter.ts
+++ b/src/transport/http/http-json-sample-adapter.ts
@@ -13,7 +13,7 @@ export class HttpJsonSampleAdapter implements IHttpAdapter {
   private token: string | null = null
   private readonly routes: Map<string, IHtmlRoute> = new Map<string, IHtmlRoute>()
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig) {
-    this.logger = config.logFactory.logger('http.adapter')
+    this.logger = config.logFactory.logger('http.adapter', { component: 'HttpJsonSampleAdapter' })
     const routes = this.routes
     const options = config?.description?.application?.http?.options
     if (!options) {

--- a/src/transport/session/fix-session.ts
+++ b/src/transport/session/fix-session.ts
@@ -61,7 +61,8 @@ export abstract class FixSession extends events.EventEmitter {
         heartBeat: config.description.HeartBtInt,
         lastPeerMsgSeqNum: config.description.LastReceivedSeqNum
       })
-    this.sessionLogger = config.logFactory.logger(`${this.me}:FixSession`)
+    this.sessionLogger = config.logFactory.logger(`${this.me}:FixSession`,
+      { component: 'FixSession', app: this.me, role: description?.application?.type })
     this.initiator = description?.application?.type === 'initiator'
     this.acceptor = !this.initiator
     this.checkMsgIntegrity = this.acceptor

--- a/src/transport/session/session-registry.ts
+++ b/src/transport/session/session-registry.ts
@@ -53,7 +53,7 @@ export class SessionRegistry implements ISessionRegistry {
   private readonly logger: IJsFixLogger | null
 
   constructor (logFactory?: JsFixLoggerFactory) {
-    this.logger = logFactory?.logger('SessionRegistry') ?? null
+    this.logger = logFactory?.logger('SessionRegistry', { component: 'SessionRegistry' }) ?? null
   }
 
   public get count (): number {

--- a/src/transport/tcp/recovering-tcp-initiator.ts
+++ b/src/transport/tcp/recovering-tcp-initiator.ts
@@ -39,7 +39,8 @@ export class RecoveringTcpInitiator extends FixEntity {
     super(jsFixConfig)
     this.application = this.jsFixConfig.description.application ?? null
     const name = this.application?.name ?? 'na'
-    this.logger = jsFixConfig.logFactory.logger(`${name}:RecoveringTcpInitiator`)
+    this.logger = jsFixConfig.logFactory.logger(`${name}:RecoveringTcpInitiator`,
+      { component: 'RecoveringTcpInitiator', app: name, role: 'initiator' })
     if (!this.application) {
       throw new Error('no application in session description.')
     }

--- a/src/transport/tcp/tcp-acceptor-listener.ts
+++ b/src/transport/tcp/tcp-acceptor-listener.ts
@@ -27,7 +27,8 @@ export class TcpAcceptorListener extends FixEntity {
 
   async start (): Promise<any> {
     return await new Promise<any>(async (resolve, reject) => {
-      const logger = this.config.logFactory.logger('acceptor')
+      const logger = this.config.logFactory.logger('acceptor',
+        { component: 'TcpAcceptorListener', role: 'acceptor' })
       const sessionContainer = this.config.sessionContainer
       if (!sessionContainer.isRegistered(DITokens.FixSession)) {
         reject(new Error(`application must register a DI token '${DITokens.FixSession}' - see src/sample`))
@@ -93,7 +94,8 @@ export class TcpAcceptorListener extends FixEntity {
    */
   stop (): void {
     if (this.acceptor) {
-      const logger = this.config.logFactory.logger('acceptor')
+      const logger = this.config.logFactory.logger('acceptor',
+        { component: 'TcpAcceptorListener', role: 'acceptor' })
       logger.info('acceptor stopping')
       this.acceptor.close(() => {
         logger.info('acceptor closed.')

--- a/src/transport/tcp/tcp-acceptor.ts
+++ b/src/transport/tcp/tcp-acceptor.ts
@@ -18,7 +18,8 @@ export class TcpAcceptor extends FixAcceptor {
 
   constructor (@inject(DITokens.IJsFixConfig) public readonly config: IJsFixConfig) {
     super(config.description.application ?? null)
-    this.logger = config.logFactory.logger(`${config.description.application?.name}:TcpAcceptor`)
+    this.logger = config.logFactory.logger(`${config.description.application?.name}:TcpAcceptor`,
+      { component: 'TcpAcceptor', app: config.description.application?.name, role: 'acceptor' })
     const tlsOptions: TlsOptions | null = this.tlsOptions()
     if (tlsOptions) {
       this.tlsServer()

--- a/src/transport/tcp/tcp-initiator-connector.ts
+++ b/src/transport/tcp/tcp-initiator-connector.ts
@@ -21,7 +21,8 @@ export class TcpInitiatorConnector extends FixEntity {
   async start (reconnectTimeout: number = 0): Promise<any> {
 
     return await new Promise<any>(async (resolve, reject) => {
-      const logger = this.config.logFactory.logger('initiator')
+      const logger = this.config.logFactory.logger('initiator',
+      { component: 'TcpInitiatorConnector', role: 'initiator' })
       const sessionContainer = this.config.sessionContainer
       if (!sessionContainer.isRegistered(DITokens.FixSession)) {
         reject(new Error(`application must register a DI token '${DITokens.FixSession}' - see src/sample`))
@@ -64,7 +65,8 @@ export class TcpInitiatorConnector extends FixEntity {
   }
 
   async connect (initiatorSession: FixSession): Promise<any> {
-    const logger = this.config.logFactory.logger('initiator')
+    const logger = this.config.logFactory.logger('initiator',
+      { component: 'TcpInitiatorConnector', role: 'initiator' })
     const initiator: FixInitiator = this.config.sessionContainer.resolve<FixInitiator>(TcpInitiator)
     logger.info('connecting ...')
     const initiatorTransport: MsgTransport = await initiator.connect(this.connectTimeoutSecs)

--- a/src/transport/tcp/tcp-initiator.ts
+++ b/src/transport/tcp/tcp-initiator.ts
@@ -33,7 +33,8 @@ export class TcpInitiator extends FixInitiator {
   constructor (@inject(DITokens.IJsFixConfig) public readonly jsFixConfig: IJsFixConfig) {
     super(jsFixConfig.description.application ?? null)
     const name = this.application?.name ?? 'initiator'
-    this.logger = jsFixConfig.logFactory.logger(`${name}:TcpInitiator`)
+    this.logger = jsFixConfig.logFactory.logger(`${name}:TcpInitiator`,
+      { component: 'TcpInitiator', app: name, role: 'initiator' })
     if (!this.application) {
       throw new Error('no application in session description.')
     }


### PR DESCRIPTION
…single log line

Filebeat wants fields, not prose.  IJsFixLogger could carry none, so nothing downstream could filter on a session or a msgType without regex over English - and the identity is not even English, it is punctuation: the logger name 'me:peer:FixSession' is built once and opaque from then on.

The leverage is not the 307 call sites, it is the 29 places a logger is made. Binding context there makes every one of the 307 lines filterable without touching any of them, and per call fields then only matter on the handful that carry a value worth aggregating - which are the same chokepoints the metrics work will need, so this pass locates them.

  logger (type: string, context?: JsFixLogFields): IJsFixLogger
  info (message: string, fields?: JsFixLogFields): void

Both arguments optional, so a client's existing one argument logger or factory subclass keeps compiling and simply ignores what it does not know about - there is a test holding that, exercised through the abstract type since that is where the engine calls it.  tsc passed on the widened interface before a single call site had been touched, which is the compatibility claim demonstrated rather than asserted.

The engine has been live for years and people have grep and scrapers built on the console format, so that output does not move.  The shipped printf names exactly four fields, so context and fields travelling as separate keys on the record are invisible to it.  Three rules fall out and each was found the hard way:

  type is passed verbatim at all 29 sites.  It cannot be derived from the
  fields - the sites share no rule, running from bare literals through one, two
  and three part composites to one dotted.  The redundancy is the price of not
  breaking grep and it is cheap.  A JSON rendering drops it, since component
  and app carry it properly and a JSON consumer is by definition new.

  Fields are namespaced rather than spread, so a caller passing { message: ... }
  cannot displace the real message, and so the formatter decides the rendering.
  That is also what makes the contract portable.

  A winston format function must mutate info rather than return a new object.
  Returning a fresh one drops Symbol.for('level') and winston discards the
  record with no output and no error.

Not true that winston gave JSON for free - consoleOptions is a printf emitting prose.  ecsOptions and ecsFileOptions are new and opt in; the console default stays as it is, not just for this release.  plain() is untouched, being a FIX wire log rather than structured log material.

Golden output tests pin the console format so anyone widening appFormat fails there rather than in someone's pipeline.

docs/instrumentation.md gains the full section: why logging lands first, the push/pull split that makes the diagnostics endpoint optional rather than a prerequisite, the field vocabulary, why fix.session in canonical form waits for the metrics work, and how this maps onto BeginScope and message templates without forcing the TypeScript shape onto C#.

Per call fields on the chosen lines, and the demo app, are not in this commit.