### PR TITLE
fix(config): stop the ECS log record repeating itself

### DIFF
--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -260,6 +260,20 @@ ECS names where they exist — `service.name`, `log.level`, `error.message`,
 `error.stack_trace` — and everything engine-specific under `fix.*`. Context keys are plain
 words; the formatter applies the prefix.
 
+Two things the ECS format does that the console one must not, both found by reading real
+output rather than by design:
+
+- **winston's own `level` is dropped.** It would otherwise sit beside `log.level` carrying
+  the same value on every line. Transports filter on `Symbol.for('level')`, not the
+  property, so removing it changes nothing about what gets logged.
+- **an error's message is the bare `Error.message`.** The console record composes
+  `message : stack` because that is what has always been rendered there; in JSON the stack
+  has `error.stack_trace` of its own, and repeating it doubles the largest line a pipeline
+  carries.
+
+Neither touches how the record is built, only how the ECS format reads it — so a caller who
+supplied their own format via `fileOptions` still sees exactly what they saw before.
+
 | context key | rendered | meaning |
 | --- | --- | --- |
 | `component` | `fix.component` | the class, e.g. `FixSession`, `TcpAcceptor` |

--- a/src/config/winston-logger.ts
+++ b/src/config/winston-logger.ts
@@ -37,9 +37,17 @@ export class WinstonLogger {
     info['log.level'] = info.level
     info['service.name'] = 'jspurefix'
     delete info.timestamp
+    // winston sets its own level, and emitting it beside the ECS name puts the same
+    // value on every line twice.  the transport filters on Symbol.for('level'), not
+    // this property, so dropping it changes nothing about what gets logged
+    delete info.level
     if (err) {
       info['error.message'] = err.message
       info['error.stack_trace'] = err.stack
+      // the record composed for the console carries the stack inside the message,
+      // because that is what has always been rendered there.  here the stack has a
+      // field of its own, so repeating it in the message only doubles the line
+      info.message = err.message
     }
     for (const key of Object.keys(context)) {
       info[`fix.${key}`] = context[key]

--- a/src/test/config/structured-logging.test.ts
+++ b/src/test/config/structured-logging.test.ts
@@ -114,6 +114,40 @@ describe('ecs format carries the structure', () => {
   })
 
   /**
+   * the console record composes the stack into the message because that is what has
+   * always been rendered there.  here it has a field of its own, so repeating it would
+   * only double the line - errors are the largest thing a log pipeline carries
+   */
+  test('an error message does not repeat the stack it already has a field for', () => {
+    const e = new Error('boom')
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.error(e) }, TYPE, CONTEXT)
+    const o = parse(lines[0])
+    expect(o.message).toEqual('boom')
+    expect(o.message).not.toContain('at ')
+  })
+
+  /**
+   * winston keeps its own level property, and emitting it beside the ECS name puts the
+   * same value on every line twice.  the transport filters on Symbol.for('level'), so
+   * dropping it does not affect what gets logged - covered by the level test below
+   */
+  test('the winston level is not emitted beside log.level', () => {
+    const lines = render(WinstonLogger.ecsOptions(), l => { l.info(MESSAGE) }, TYPE, CONTEXT)
+    const o = parse(lines[0])
+    expect(o['log.level']).toEqual('info')
+    expect(o.level).toBeUndefined()
+  })
+
+  test('level filtering still applies once level has been dropped', () => {
+    const lines = render(WinstonLogger.ecsOptions('warn'), l => {
+      l.info('below the threshold')
+      l.warning('at the threshold')
+    }, TYPE, CONTEXT)
+    expect(lines.length).toEqual(1)
+    expect(parse(lines[0]).message).toEqual('at the threshold')
+  })
+
+  /**
    * a caller cannot clobber the record by naming a reserved key, because the bags are
    * nested rather than spread
    */


### PR DESCRIPTION
Two things the demo's real output showed that the hand written examples did not, both on every line or every error rather than occasionally.

winston sets its own level property, so a record carried "level":"info" beside "log.level":"info" - the same value twice on every line ever emitted. Transports filter on Symbol.for('level') rather than the property, verified by logging below the threshold with it deleted and watching the record still get filtered, so dropping it changes nothing about what is logged.

An error's message was the console composition, message and stack together, while error.stack_trace carried the stack again.  Errors are the largest thing a log pipeline moves and that made them roughly twice the size they need to be. In JSON the stack has a field of its own, so the message is now just Error.message.

Both are changes to how the ECS format reads the record, not to how make() builds it or to appFormat.  That matters: the console rendering is untouched, and so is anything a caller passes to fileOptions as their own format - moving the composition out of the record would have silently dropped the stack from those.

Four tests added, including one that logs below the threshold to hold the level filtering that dropping the property depends on.